### PR TITLE
I have gone through the list of plugins and done the following:

### DIFF
--- a/grails-plugins.json
+++ b/grails-plugins.json
@@ -6,9 +6,8 @@
             "owner": "dmahapatro",
             "desc": "Grails actuator-ui plugin",
             "labels": [
-                "grails3",
-                "spring-boot",
-                "spring-boot-actuator"
+                "spring-boot-actuator",
+                "health-check"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -26,13 +25,14 @@
         "readme": "<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p><span class=\"image\"><a class=\"image\" href=\"https://travis-ci.org/dmahapatro/grails-actuator-ui\"><img src=\"https://travis-ci.org/dmahapatro/grails-actuator-ui.svg?branch=master\" alt=\"Build Status\"></a></span>\n<span class=\"image\"><a class=\"image\" href=\"https://bintray.com/dmahapatro/plugins/actuator-ui/_latestVersion\"><img src=\"https://api.bintray.com/packages/dmahapatro/plugins/actuator-ui/images/download.svg\" alt=\"download\"></a></span></p>\n</div>\n<div class=\"paragraph\">\n<p><a href=\"http://docs.spring.io/autorepo/docs/spring-boot/current/reference/htmlsingle/#production-ready\">Spring Actuator</a> is a tool which monitors application&#8217;s <code>health</code>, <code>metrics</code> and lots of other metadata information about the application.\nThis plugin projects those information in a UI which makes it very user friendly to know the status of the application.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_demo\">Demo</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p><a href=\"https://www.youtube.com/watch?v=huhC1LV5I8Q\">DEMO</a></p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_prerequisites\">Prerequisites</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist\">\n<ul>\n<li>\n<p>For Grails 3.0.* version 0.2 can be used</p>\n</li>\n<li>\n<p>For Grails 3.1.* version 1.0 should be used</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_configuration\">Configuration</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p><code>build.gradle</code></p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre class=\"highlight\"><code class=\"language-groovy\" data-lang=\"groovy\">repositories {\n    maven {\n        url  \"http://dl.bintray.com/dmahapatro/plugins\"\n    }\n}\n\ndependencies {\n    ...\n    compile \"org.grails.plugins:actuator-ui:1.1\"\n}</code></pre>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_how_to\">How To</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>To access the actuator endpoints you can simply hit <code>/actuator/dashboard</code> at root context.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre class=\"highlight\"><code class=\"language-groovy\" data-lang=\"groovy\">http://localhost:8080/sample/actuator/dashboard</code></pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>where <code>/sample</code> is the root context of the application. For a base Grails app where root context is <code>/</code>, the url will be</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre class=\"highlight\"><code class=\"language-groovy\" data-lang=\"groovy\">http://localhost:8080/actuator/dashboard</code></pre>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_secured\">Secured</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>Actuator UI is targeted for Admins and normal users. Taking ROLE into consideration this plugin can be easily integrated with spring security core plugin. For example with a mapping like the below in <code>application.yml</code> would secure <code>/actuator/dashboard</code> endpoint.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre class=\"highlight\"><code class=\"language-yaml\" data-lang=\"yaml\">grails:\n    plugin:\n        springsecurity:\n            userLookup:\n                userDomainClassName: auth.User\n                authorityJoinClassName: auth.UserRole\n            authority:\n                className: auth.Role\n            controllerAnnotations:\n                staticRules:\n                    - pattern: '/actuatordashboard/**'\n                      access: ['hasRole(\"ROLE_ADMIN\")']\n                    - pattern: '/actuator/**'\n                      access: ['hasRole(\"ROLE_ADMIN\")']</code></pre>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_avatar_support\">Avatar support</h3>\n<div class=\"paragraph\">\n<p>Actuator-ui ships with Gravatar plugin. It will render a gravatar image under the following circumstances:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Spring Security is installed</p>\n</li>\n<li>\n<p>The user is logged in</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Gravatar is enabled for actuator-ui by default. To disable Gravatar in actuator-ui, you should add the following to application&#8217;s <code>application.yml</code>.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre class=\"highlight\"><code class=\"language-yaml\" data-lang=\"yaml\">grails:\n    plugin:\n        actuator:\n            gravatar:\n                disabled: true</code></pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>To modify the default rating and gravatar fallback image please refer to the <a href=\"https://github.com/rpalcolea/grails-gravatar\">Gravatar Plugin Documentation</a></p>\n</div>\n<div class=\"admonitionblock note\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Note</div>\n</td>\n<td class=\"content\">\n<strong>When <code>spring security</code> and <code>gravatar</code> are enabled, the plugin grabs the username to look for the gravatar. In this case the username should be a valid email registered in Gravatar otherwise it will fallback to the default gravatar image.</strong>\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_sample\">Sample</h3>\n<div class=\"paragraph\">\n<p>Sample apps with Spring Security Core integration:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Run <a href=\"https://github.com/dmahapatro/grails-actuator-ui/tree/master/actuator-ui-app\">actuator-ui-app</a> available as sub project in this plugin repository.</p>\n</li>\n<li>\n<p>Run <a href=\"https://bitbucket.org/bgoetzmann/odelia-gina-actuator/overview\">sample app</a> created by Bertrand Goetzmann.</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_v1_1\">v1.1</h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Gravatar support added for logged in user.</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_v1_0\">v1.0</h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Grails upgraded to v3.1.10</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_v0_2\">v0.2</h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Integrated console plugin. A link is provided in the header bar to open console via console plugin. Appropriate version of console plugin has to be installed in the app which uses this plugin. If console plugin is added as a dependency then actuator dashboard should show console link next to the logged in user in top right corner.</p>\n</li>\n<li>\n<p>Items are searchable now. Search for a particular bean, mapping, calls etc.</p>\n</li>\n<li>\n<p>Paginated list of items.</p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_todo\">TODO</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Add charts on Garbage Collection metrics.</p>\n</li>\n<li>\n<p>Add support for custom address and port.</p>\n</li>\n</ul>\n</div>\n</div>\n</div>"
     },
     {
+        "displayName": "airbrake",
         "bintrayPackage": {
             "name": "airbrake-grails",
             "repo": "plugins",
             "owner": "bostanio",
             "desc": "Airbrake Client for Grails",
             "labels": [
-                
+                "airbrake"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -56,7 +56,7 @@
             "owner": "grails",
             "desc": "Grails ajax-tags plugin",
             "labels": [
-                
+                "ajax"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -74,13 +74,14 @@
         "readme": null
     },
     {
+        "displayName": "ajax-dependency-selection",
         "bintrayPackage": {
             "name": "ajaxdependancyselection",
             "repo": "maven",
             "owner": "vahid",
             "desc": "Grails ajaxdependancyselection plugin",
             "labels": [
-                
+                "ajax"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -104,7 +105,8 @@
             "owner": "rvanderwerf",
             "desc": "This is a Grails 3.x plugin to help make Amazon Alexa Skills /  Speechlets",
             "labels": [
-                
+                "amazon",
+                "alexa"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -128,21 +130,21 @@
             "owner": "craigburke",
             "desc": "AngularJS Annotate for Asset Pipeline 2.0+",
             "labels": [
-                
+                "angular-1"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/craigburke/angular-annotate-asset-pipeline/issues",
             "latestVersion": "2.4.1",
-            "updated": "2016-05-27T15:29:24.507Z",
+            "updated": "2016-05-13T16:12:37.000Z",
             "systemIds": [
                 "com.craigburke.angular:angular-annotate-asset-pipeline"
             ],
-            "vcsUrl": ""
+            "vcsUrl": "https://github.com/craigburke/angular-annotate-asset-pipeline"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/craigburke/angular/angular-annotate-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -152,14 +154,14 @@
             "owner": "grails",
             "desc": "Provides scaffolding for AngularJS 1.x applications",
             "labels": [
-                
+                "angular-1"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails-plugins/grails-angular-scaffolding/issues",
             "latestVersion": "2.0.0",
-            "updated": "2017-12-05T15:47:14.862Z",
+            "updated": "2017-07-03T19:48:13.000Z",
             "systemIds": [
                 "org.grails.plugins:angular-scaffolding"
             ],
@@ -176,7 +178,8 @@
             "owner": "craigburke",
             "desc": "AngularJS Templates for Asset Pipeline 2.0+",
             "labels": [
-                
+                "angular-1",
+                "asset-pipeline"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -187,10 +190,10 @@
             "systemIds": [
                 "com.craigburke.angular:angular-template-asset-pipeline"
             ],
-            "vcsUrl": ""
+            "vcsUrl": "https://github.com/craigburke/angular-template-asset-pipeline"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/craigburke/angular/angular-template-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -200,7 +203,7 @@
             "owner": "grails",
             "desc": "Provides scaffolding for Angular 2 applications",
             "labels": [
-                
+                "angular-2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -213,9 +216,9 @@
             ],
             "vcsUrl": "https://github.com/grails-plugins/grails-angular2-scaffolding"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-angular-scaffolding/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-angular-scaffolding/latest/",
         "mavenMetadataUrl": null,
-        "readme": "<h1>Grails 3 Angular Scaffolding Plugin</h1>\n<p><a href=\"https://travis-ci.org/grails-plugins/grails-angular-scaffolding\"><img src=\"https://travis-ci.org/grails-plugins/grails-angular-scaffolding.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>A plugin for generating client side assets based on domain classes</p>\n<h2>Documentation</h2>\n<p>Latest: http://grails-plugins.github.io/grails-angular-scaffolding/latest\nSnapshot: http://grails-plugins.github.io/grails-angular-scaffolding/snapshot</p>\n"
+        "readme": "<h1>Grails 3 Angular Scaffolding Plugin</h1>\n<p><a href=\"https://travis-ci.org/grails-plugins/grails-angular-scaffolding\"><img src=\"https://travis-ci.org/grails-plugins/grails-angular-scaffolding.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>A plugin for generating client side assets based on domain classes</p>\n<h2>Documentation</h2>\n<p>Latest: https://grails-plugins.github.io/grails-angular-scaffolding/latest\nSnapshot: https://grails-plugins.github.io/grails-angular-scaffolding/snapshot</p>\n"
     },
     {
         "bintrayPackage": {
@@ -224,7 +227,7 @@
             "owner": "grails",
             "desc": "Provides scaffolding for AngularJS 1.x applications",
             "labels": [
-                
+                "angular-1"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -237,18 +240,19 @@
             ],
             "vcsUrl": "https://github.com/grails-plugins/grails-angularjs-scaffolding"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-angularjs-scaffolding/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-angularjs-scaffolding/latest/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Grails 3 AngularJS Scaffolding Plugin</h1>\n<p><a href=\"https://travis-ci.org/grails-plugins/grails-angularjs-scaffolding\"><img src=\"https://travis-ci.org/grails-plugins/grails-angularjs-scaffolding.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>A plugin for generating client side assets based on domain classes</p>\n<h2>Documentation</h2>\n<p>http://grails-plugins.github.io/grails-angularjs-scaffolding/latest</p>\n"
     },
     {
+        "deprecated": "Source repository is archived and no Grails >= 3 plugin library published. This entry should probably be removed from the registry.",
         "bintrayPackage": {
             "name": "anthofo.plugins:json-annotations-marshaller",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "anthofo",
             "desc": "Grails json-annotations-marshaller plugin",
             "labels": [
-                
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -257,7 +261,7 @@
             "latestVersion": "1.0",
             "updated": "2016-03-31T16:14:33.462Z",
             "systemIds": [
-                
+
             ],
             "vcsUrl": "https://github.com/anthofo/grails3-json-annotations-marshaller"
         },
@@ -272,7 +276,7 @@
             "owner": "neilab",
             "desc": "Allows external configuration via grails.config.locations, JNDI, and system properties",
             "labels": [
-                
+                "config"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -290,13 +294,14 @@
         "readme": "<h1>Application-Config</h1>\n<p><a href=\"https://travis-ci.org/neilabdev/application-config\"><img src=\"https://travis-ci.org/neilabdev/application-config.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>This plugin based on the amazing work started in plugin  <a href=\"http://plugins.grails.org/plugin/grails/external-config\">external-config</a> by <a href=\"https://github.com/snimavat\">Sudhir Nimavat</a> and  <a href=\"https://github.com/tkvw\">Dennie de Lange</a>,\nwhich mimiced the Grails 2 way of handling external configurations defined in <code>grails.config.locations</code>; with the necessary additions to allow configurations via command line, system properties, and JNDI.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/neilabdev\">neilabdev</a></li>\n</ul>\n<h2>Installation</h2>\n<p>Add dependency to your <code>build.gradle</code>:</p>\n<pre><code>dependencies {\n    compile 'com.neilab.plugins:application-config:1.1.3'\n}\n</code></pre>\n<h2>Usage</h2>\n<p>When you add this plugin to your Grails build, it will automatically look for the property <code>grails.config.locations</code>. Define this in in either <code>application.yml</code> like this:</p>\n<pre><code>grails:\n    config:\n        locations:\n            - classpath:myconfig.groovy\n            - classpath:myconfig.yml\n            - classpath:myconfig.properties\n            - file:///etc/app/myconfig.groovy\n            - file:///etc/app/myconfig.yml\n            - file:///etc/app/myconfig.properties\n            - ~/.grails/myconfig.groovy\n            - ~/.grails/myconfig.yml\n            - ~/.grails/myconfig.properties\n            - file:${catalina.base}/myconfig.groovy\n            - file:${catalina.base}/myconfig.yml\n            - file:${catalina.base}/myconfig.properties\n</code></pre>\n<p>or in <code>application.groovy</code> like this:</p>\n<pre><code>grails.config.locations = [\n        &quot;classpath:myconfig.groovy&quot;,\n        &quot;classpath:myconfig.yml&quot;,\n        &quot;classpath:myconfig.properties&quot;,\n        &quot;file:///etc/app/myconfig.groovy&quot;,\n        &quot;file:///etc/app/myconfig.yml&quot;,\n        &quot;file:///etc/app/myconfig.properties&quot;,\n        &quot;~/.grails/myconfig.groovy&quot;,\n        &quot;~/.grails/myconfig.yml&quot;,\n        &quot;~/.grails/myconfig.properties&quot;,\n        'file:${catalina.base}/myconfig.groovy',\n        'file:${catalina.base}/myconfig.yml',\n        'file:${catalina.base}/myconfig.properties',\n]\n</code></pre>\n<p>You may also include external configs using '-D' arguments which match the system properties\nthe application is seeking, preceded by an application prefix determined by <em>info.app.name</em> in your default <em>application.yml</em>, <em>application.groovy</em>  or &quot;app&quot; if none exists. By default the following should work:</p>\n<pre><code>-DappName.config=&quot;/path/to/config&quot;\n-DappName.external.config=&quot;/path/to/config&quot;\n-DappName.database.config=&quot;/path/to/config&quot;\n-DappName.logging.config=&quot;/path/to/config&quot;\n\n</code></pre>\n<p>or using JNDI variables <em>CONFIG</em>, <em>EXTERNAL_CONFIG</em>, <em>LOGGING_CONFIG</em>, <em>DATABASE_CONFIG</em> in tomcat for example:</p>\n<pre><code class=\"language-xml\">&lt;Context path=&quot;&quot; docBase=&quot;/path/to/app.war&quot;  reloadable=&quot;false&quot;&gt;\n        &lt;Environment name=&quot;APP_CONFIG&quot;\n                value=&quot;file:/path/to/external_config.groovy&quot;\n                type=&quot;java.lang.String&quot;/&gt;\n        &lt;Environment name=&quot;DATABASE_CONFIG&quot;\n                value=&quot;file:/path/to/external_config.database.groovy&quot;\n                type=&quot;java.lang.String&quot;/&gt;\n&lt;/Context&gt;\n</code></pre>\n<p>While  no-longer necessary as of version 1.1.0 of <a href=\"http://plugins.grails.org/plugin/grails/external-config\">external-config</a>, which this fork is based, for comparability you  may edit your Grails projects <code>Application.groovy</code> and implement the trait <code>com.neilab.plugins.config.ApplicationConfig</code> (formally ExternalConfig):</p>\n<pre><code>import com.neilab.plugins.config.ApplicationConfig\n\nclass Application extends GrailsAutoConfiguration implements ApplicationConfig {\n    static void main(String[] args) {\n        GrailsApp.run(Application, args)\n    }\n}\n</code></pre>\n<p>This above is necessary only when <em>ApplicationConfigRunListener</em> is not executed, and   personally  have used it only when developing the plugin as an inline plugin where <em>SpringApplicationRunListener</em> was not loaded.</p>\n<h2>Notes</h2>\n<p>Notice, that <code>~/</code> references the users <code>$HOME</code> directory.\nNotice, that using a system property you should use single quotes because otherwise it's interpreted as a Gstring.</p>\n<p>The plugin will skip configuration files that are not found.</p>\n<p>For <code>.groovy</code> and <code>.yml</code> files the <code>environments</code> blocks in the config file are interpreted the same way, as in <code>application.yml</code> or <code>application.groovy</code>.</p>\n<p>Alternatively, you can make a gradle script to move the external configuration file to your classpath (e.g. /build/classes)</p>\n<p><strong>Using IntelliJ or gradle to specify configurations via system properties</strong></p>\n<p>When passing system properties via <em>VM Options</em> in IntelliJ or <em>-D</em> properties in gradle, it may be necessary to assign the parameters to the app via <em>bootRun</em> in your <em>build.gradle</em> configuration.</p>\n<pre><code class=\"language-groovy\">//build.gradle\nbootRun {\n    systemProperties = System.properties\n}\n</code></pre>\n<h2>Scripts</h2>\n<p>This plugin also includes two scripts, one for converting yml config, to groovy config,\nand one for converting groovy config to yml config. These scripts are not guaranteed to be\nperfect, but you should report any edge cases for the yml to groovy config here:\nhttps://github.com/virtualdogbert/GroovyConfigWriter/issues</p>\n<p>Sample usage:</p>\n<pre><code>grails yml-to-groovy-config [ymlFile] [optional outputFile]\ngrails groovy-to-yml-config [ymlFile] [optional outputFile]\n</code></pre>\n"
     },
     {
+        "deprecated":  "This entry in the registry seems to be a duplicate of the entry named 'asset-pipeline-grails'. It should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "asset-pipeline",
             "repo": "plugins",
             "owner": "grails",
             "desc": "Grails asset-pipeline plugin",
             "labels": [
-                
+                "asset-pipeline"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -320,21 +325,21 @@
             "owner": "bertramlabs",
             "desc": "The Asset-Pipeline is a plugin used for managing and processing static assets in Grails applications. Asset-Pipeline functions include processing and minification of both CSS and JavaScript files. It is also capable of being extended to compile custom static assets, such as CoffeeScript.",
             "labels": [
-                
+                "asset-pipeline"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
             "latestVersion": "3.3.1",
-            "updated": "2020-09-24T14:08:44.729Z",
+            "updated": "2022-11-03T15:33:22.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:asset-pipeline-grails"
             ],
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/asset-pipeline-grails/maven-metadata.xml",
         "readme": null
     },
     {
@@ -344,7 +349,8 @@
             "owner": "dpcasady",
             "desc": "Grails asset pipeline handlebars templates renderer plugin",
             "labels": [
-                
+                "asset-pipeline",
+                "handlebars"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -368,7 +374,7 @@
             "owner": "grails",
             "desc": "Grails Async - Grails Async Libraries",
             "labels": [
-                
+                "async"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -392,6 +398,7 @@
             "owner": "gpc",
             "desc": "The plugin realises asynchronous mail sending. It stores messages in a DB and sends them asynchronously by a quartz job.",
             "labels": [
+                "async",
                 "mail"
             ],
             "licenses": [
@@ -410,29 +417,27 @@
         "readme": "<p><a href=\"https://github.com/gpc/grails-asynchronous-mail\">See the README</a> on GitHub</p>"
     },
     {
+        "comment": "This entry has had its owner changed from robertoschwald to symentis as that seems to be the maintained repo going forward. This comment can be removed if this is correct.",
         "bintrayPackage": {
             "name": "audit-logging",
             "repo": "plugins",
-            "owner": "robertoschwald",
-            "desc": "Grails 3.x Audit-Logging Plugin.",
+            "owner": "symentis",
+            "desc": "Grails Audit-Logging Plugin.",
             "labels": [
-                "audit-logging",
-                "GORM",
-                "Grails",
-                "plugin"
+                "auditing"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/robertoschwald/grails-audit-logging-plugin/issues",
+            "issueTrackerUrl": "https://github.com/symentis/grails-audit-logging-plugin/issues",
             "latestVersion": "4.0.3",
             "updated": "2021-02-03T16:27:11.971Z",
             "systemIds": [
                 "org.grails.plugins:audit-logging"
             ],
-            "vcsUrl": "https://github.com/robertoschwald/grails-audit-logging-plugin"
+            "vcsUrl": "https://github.com/symentis/grails-audit-logging-plugin"
         },
-        "documentationUrl": "https://robertoschwald.github.io/grails-audit-logging-plugin/",
+        "documentationUrl": "https://symentis.github.io/grails-audit-logging-plugin",
         "mavenMetadataUrl": null,
         "readme": "<h1>Grails Audit Logging Plugin</h1>\n<h2>Description</h2>\n<p>The Audit Logging plugin for Grails adds generic event based Audit Logging to a Grails project.</p>\n<p>The master branch holds the codebase for plugin version 4.0.x (Grails 4.0.x).</p>\n<p>We currently work on a Grails 4.x branch using a new approach. See <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/pull/212\">PR 212</a></p>\n<p>For older Grails versions, see &quot;Supported Grails Versions&quot; below.</p>\n<h2>Documentation</h2>\n<ul>\n<li>For current release documentation, see <a href=\"https://robertoschwald.github.io/grails-audit-logging-plugin/latest/plugin.html\">User Guide</a></li>\n<li>For snapshot documentation, see <a href=\"https://robertoschwald.github.io/grails-audit-logging-plugin/snapshot/plugin.html\">Snapshot User Guide</a></li>\n<li>For 3.x documentation, see <a href=\"https://robertoschwald.github.io/grails-audit-logging-plugin/3.0.x/plugin.html\">3.x User Guide</a></li>\n<li>For 2.x documentation, see <a href=\"https://robertoschwald.github.io/grails-audit-logging-plugin/2.0.x/plugin.html\">2.x User Guide</a></li>\n<li>For 1.x documentation, see <a href=\"http://grails.org/plugin/audit-logging\" title=\"Grails Plugin Page\">1.x Grails Plugin Page</a></li>\n</ul>\n<h2>Supported Grails versions</h2>\n<ul>\n<li>Grails 4.0.x: <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/tree/master\">master branch</a> <a href=\"https://bintray.com/robertoschwald/plugins/audit-logging/_latestVersion\"><img src=\"https://api.bintray.com/packages/robertoschwald/plugins/audit-logging/images/download.svg\" alt=\"Download\" /></a></li>\n<li>Grails 3.3.x: <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/tree/3.x_maintenance\">3.x_maintenance branch</a> <a href=\"https://bintray.com/robertoschwald/plugins/audit-logging/3.0.6/link\"><img src=\"https://api.bintray.com/packages/robertoschwald/plugins/audit-logging/images/download.svg?version=3.0.6\" alt=\"Download\" /></a></li>\n<li>Grails 3.0.x-3.2.x: <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/tree/2.x_maintenance\">2.x_maintenance branch</a> <a href=\"https://bintray.com/robertoschwald/plugins/audit-logging/2.0.6/link\"><img src=\"https://api.bintray.com/packages/robertoschwald/plugins/audit-logging/images/download.svg?version=2.0.6\" alt=\"Download\" /></a></li>\n<li>Grails 2.x: <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/tree/1.x_maintenance\">1.x_maintenance branch</a></li>\n</ul>\n<h2>audit-quickstart</h2>\n<p>You need to perform &quot;grails audit-quickstart &lt;package&gt; &lt;DomainClass&gt;&quot; after installing this plugin's 2.0.x version or later.</p>\n<p>With this, you get an auditlog domain class in your project which is fully under your control.\nThe domain name is registered in your application.groovy with key &quot;grails.plugins.auditLog.auditDomainClassName&quot;.</p>\n<p>Example:</p>\n<pre><code>grails audit-quickstart org.example.myproject MyAuditLogEvent\n</code></pre>\n<h2>Issue Management</h2>\n<p>See <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/issues\" title=\"Issues\">GitHub Issues</a></p>\n<h2>Pull Requests</h2>\n<p>Pull requests are highly appreciated and welcome!</p>\n<p>Please add integration tests for new features to the audit-test application.</p>\n<h2>Contributors</h2>\n<p>Special thanks to all the <a href=\"https://github.com/robertoschwald/grails-audit-logging-plugin/graphs/contributors\">contributors</a> (in alphabetical order):</p>\n<pre><code>Aaron Long\nAldrin\nAndrey Zhuchkov\nAnkur Tripathi\nBurt Beckwith\nbzamora33\nDanny Casady\nDennie de Lange\nDhiraj Mahapatro\nElmar Kretzer\nFelix Scheinost\nFernando Cambarieri\nGraeme Rocher\nJeff Palmer\nJorge Aguilera\nJuergen Baumann\nMadhava Jay\nMatt Long\nMatthew A Stewart\nPaul Taylor\nSami M\ufffd\ufffd\ufffd\ufffdkel\ufffd\ufffd\ufffd\ufffd\nSebastien Arbogast\nSemyon Atamas\nShawn Hartsock\nTom Crossland\n\nProject lead: Robert Oschwald\n</code></pre>\n<h2>Continuous Integration Server</h2>\n<p><a href=\"https://travis-ci.org/robertoschwald/grails-audit-logging-plugin\"><img src=\"https://travis-ci.org/robertoschwald/grails-audit-logging-plugin.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>Bintray Repository</h2>\n<p><a href='https://bintray.com/robertoschwald/plugins/audit-logging/view?source=watch' alt='Get automatic notifications about new \"audit-logging\" versions'><img src='https://www.bintray.com/docs/images/bintray_badge_color.png'></a></p>\n<p><a href=\"https://bintray.com/robertoschwald/plugins/audit-logging/_latestVersion\"><img src=\"https://api.bintray.com/packages/robertoschwald/plugins/audit-logging/images/download.svg\" alt=\"Download\" /></a></p>\n<hr />\n<p><a href=\"https://www.yourkit.com/java/profiler/index.jsp\"><img src=\"https://www.yourkit.com/images/yklogo.png\" alt=\"YourKit Java Profiler\"/></a></p>\n<p>YourKit is kindly supporting Grails open source projects with its full-featured Java Profiler.\nYourKit, LLC is the creator of innovative and intelligent tools for profiling\nJava and .NET applications. Take a look at YourKit's leading software products:\n<a href=\"http://www.yourkit.com/java/profiler/index.jsp\">YourKit Java Profiler</a> and\n<a href=\"http://www.yourkit.com/.net/profiler/index.jsp\">YourKit .NET Profiler</a>.</p>\n"
     },
@@ -443,7 +448,7 @@
             "owner": "9ci",
             "desc": "Audit Trails Grails Plugin",
             "labels": [
-                
+                "auditing"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -461,22 +466,32 @@
         "readme": "<p><a href=\"https://circleci.com/gh/yakworks/view-tools\"><img src=\"https://img.shields.io/circleci/project/github/9ci/grails-audit-trail/master.svg?longCache=true&amp;style=for-the-badge&amp;logo=circleci\" alt=\"CircleCI\" /></a>\n<a href=\"http://9ci.com\"><img src=\"https://img.shields.io/badge/BUILT%20BY-9ci%20Inc-blue.svg?longCache=true&amp;style=for-the-badge\" alt=\"9ci\" /></a>\n<img src=\"https://forthebadge.com/images/badges/built-with-love.svg\" height=\"28\">\n<a href=\"https://forthebadge.com\"><img src=\"https://forthebadge.com/images/badges/made-with-groovy.svg\" alt=\"forthebadge\" /></a>\n<img src=\"https://forthebadge.com/images/badges/gluten-free.svg\" height=\"28\">\n<a href=\"https://forthebadge.com\"><img src=\"https://forthebadge.com/images/badges/approved-by-george-costanza.svg\" alt=\"forthebadge\" /></a></p>\n<h2>Install</h2>\n<pre><code class=\"language-groovy\">compile &quot;org.grails.plugins:audit-trail:3.0.11&quot;\n\n</code></pre>\n<h1>Overview</h1>\n<p>This plugin lets you add an annotation to your domain classes so the necessary created/updated audit fields will get added. On save() the domain will get &quot;stamped&quot; after a new insert or update. This eliminates the need for setting up a base class.\nIt will automatically add fields based on your settings in Config.groovy.\nProvides an AST transformation annotation and hibernate events to take care of &quot;stamping&quot; for your gorm objects with the user who edited and/or created it as well as the edited and created dates.</p>\n<h1>Goals</h1>\n<ul>\n<li>DRY - setup config and then a single @gorm.AuditStamp on your domain will give the fields</li>\n<li>Eliminate the need for a base class to store audit fields</li>\n<li>Provide more the ability to configure the names of the date and user fields. It was a big break in our standard to use &quot;dateCreated&quot; and &quot;lastUpdated&quot;</li>\n<li>Keep the nullable:false constraint on the audit fields with the ability to configure and override it if need be.</li>\n<li>work with Joda or with normal Date</li>\n</ul>\n<h1>Using the @gorm.AuditStamp annotation</h1>\n<p>Add to your config.groovy each field you want added</p>\n<p>grails{\nplugin{\naudittrail{\t\ncreatedBy.field   = &quot;createdBy&quot; //add whatever names you want used for the\neditedBy.field    = &quot;editedBy&quot;\ncreatedDate.field = &quot;createdDate&quot;\neditedDate.field  = &quot;editedDate&quot;\n}\n}\n}</p>\n<p>Add the annotation to your domain class</p>\n<pre><code>@gorm.AuditStamp\nclass Note{\n\tString note\n}\n</code></pre>\n<p>During compile time the AST transformation will add fields just as if you wrote your domain like so:</p>\n<pre><code>class Note{\n\tString note\n\t\n\tLong createdBy \n\tLong editedBy \n\tDate editedDate\n\tDate createdDate \n\t\n\tstatic constaints = {\n\t\tcreatedBy   nullable:false,display:false,editable:false\n\t\teditedBy    nullable:false,display:false,editable:false\n\t\teditedDate  nullable:false,display:false,editable:false\n\t\tcreatedDate nullable:false,display:false,editable:false\n\t}\n\t\n\tdef beforeValidate() { //if this already existed then it just append the code\n\t\t//this sets the fields if this is a new (about to be inserted) instance \n\t\t...applicationContext.getBean('auditTrailHelper').initializeFields(this)\n\t}\n\t\n}\n</code></pre>\n<h2>No annotation</h2>\n<p>The annotation is just an AST transformation as a convenience. You can add the fields manually to your domains that match whats you have configured in  config.grooy and the events will fire on those fields. This includes other hibernate/java entities.\nIt uses the AuditTrailInterceptor to stamp the fields on the hibernate objects if they exists.</p>\n<h1>Events and the interceptor</h1>\n<p>As seen in the above example, this allows you to keep your fields set to &quot;nullable:false&quot; since this annotation will add/append code to the beforeValidate() to make sure the fields are initialized properly. It also setups</p>\n<h2>Security</h2>\n<p>The plugin defaults to using Spring Security but it is not dependent on it. If no currentUserClosure</p>\n<h1>Configuration Options</h1>\n<p>The following show the options and defaults. For a field to be added by the annotation at least on config setting needs to be present.\nNOTE: Remember to clean and re-compile after changing the config settings. All of the mods to the domain happen with and AST at compile time.</p>\n<pre><code>grails{\n\tplugin{\n\t\taudittrail{\t\n\t\t\t// ** if field is not specified then it will default to 'createdBy'\n\t\t\tcreatedBy.field = &quot;createdBy&quot;  // createdBy is default\n\t\t\t// ** fully qualified class name for the type\t\n\t\t\tcreatedBy.type   = &quot;java.lang.Long&quot; //Long is the default\n\t\t\t// ** the constraints settings\n\t\t\tcreatedBy.constraints = &quot;nullable:false,display:false,editable:false,bindable:false&quot; \n\t\t\t// ** the mapping you want setup\n\t\t\tcreatedBy.mapping = &quot;column: 'inserted_by'&quot; //&lt;-example as there are NO defaults for mapping\n\t\t\t\n\t\t\tcreatedDate.field = &quot;createdDate&quot;\n\t\t\tcreatedDate.type  = &quot;java.util.DateTime&quot; \n\t\t\tcreatedDate.constraints = &quot;nullable:false,display:false,editable:false,bindable:false&quot; \n\t\t\tcreatedDate.mapping = &quot;column: 'date_created'&quot; //&lt;-NOTE: example as there are NO defaults for mapping\n\t\t\t\n\t\t\tetc.....\n\t\t\t\n\t\t\t//custom closure to return the current user who is logged in\n\t\t\tcurrentUserClosure = {ctx-&gt;\n\t\t\t\t//ctx is the applicationContext\n\t\t\t\t//default is basically\n\t\t\t\treturn springSecurityService.principal?.id\n\t\t\t}\n\t\t\t//there are NO defaults for companyId.\n\t\t\tcompanyId.field   = &quot;companyId&quot; //used for multi-tenant apps and is just the name of the field to use\n\t\t}\n</code></pre>\n<h2>Joda Time Example</h2>\n<p>this also shows how you can set your own currentUserClosure for stamping the user fields</p>\n<pre><code>grails{\n\tplugin{\n\t\taudittrail{\t\t\t\n\t\t\tcreatedBy.type   = &quot;java.lang.String&quot; \n\t\t\n\t\t\teditedBy.type   = &quot;java.lang.String&quot; \n\t\t\n\t\t\tcreatedDate.type  = &quot;org.joda.time.DateTime&quot; \n\t\t\tcreatedDate.mapping = &quot;type: org.jadira.usertype.dateandtime.joda.PersistentDateTime&quot;\n\t\t\n\t\t\teditedDate.type  = &quot;org.joda.time.DateTime&quot; \n\t\t\teditedDate.mapping = &quot;type: org.jadira.usertype.dateandtime.joda.PersistentDateTime&quot;\n\t\t\n\t\t\tcurrentUserClosure = {ctx-&gt;\n\t\t\t\treturn ctx.mySecurityService.currentUserLogin()\n\t\t\t}\n\t\t}\n\t}\n}\n</code></pre>\n<h1>Unit Testing</h1>\n<p>In Grails 2 the config is available in your unit tests so it makes setting things up a bit easier now.\ngrails.plugin.audittrail.AuditTrailHelper has a mockForUnitTest(config,userVal=1) to make unit testing easier.\npass userVal in as something else if you want some other default or some other type for your createdBy and editedBy.\nTake a look at the source if you want to see what its doing.</p>\n<pre><code>void testSave() {\n\tdef d = new TestDomain()\n\td.name = &quot;test&quot;\n\t//the AST from @gorm.AuditStamp adds a property &quot;auditTrailHelper&quot; to your domains\n\t//at run time it gets injected with the auditTrailHelper bean from the applicationContext\n\td.auditTrailHelper = AuditTrailHelper.mockForUnitTest(config)\n\td.save(failOnError:true)\n\tassert d.createdBy == 1 \n}\n</code></pre>\n<h1>changes from 1.2 -&gt; 2.0 (many are breaking)</h1>\n<ul>\n<li>defaults on the added fields are now to set nullable:true and not have default values</li>\n<li>changed the name space in config from stamp.audit to grails.plugin.audittrail</li>\n<li>major config overhall so you can set types,constraints etc for each audit field</li>\n<li>there is now an ability to set your own currrentUserClosure and the dependency on SpringSecurity is gone.</li>\n</ul>\n<h1>changes in 2.0.4</h1>\n<ul>\n<li>added mockForUnitTest in AuditTrailHelper to make unit testing easier</li>\n<li>a transient auditTrailHelper to get the injected bean for each domain that is marked with @gorm.auditStamp. beforeValidate then calls this if its not null. This will make it easier to test</li>\n</ul>\n<h1>changes in 2.1</h1>\n<ul>\n<li>added default constraint for fields of bindable:false</li>\n<li>you can turn off audit trail for an instance by setting domainInstance.disableAuditTrailStamp = true</li>\n<li>refactor common stamp functions to AuditTrailHelper</li>\n</ul>\n<h3>Using AuditTrail in gradle multimodule projects</h3>\n<p>AuditTrail AST Transoformation reads audit trail related settings from application.groovy.\nAs long as the project with AuditStamp annotation is root gradle project, it works just fine.\nHowever when the project is a module of a multimodule gradle project, A system property needs to be set to aid AST tranformation class find the correct application.groovy from module directory.</p>\n<p>This can be achieved by setting the <code>module.path</code> in build.gradle of submodule as shown below.</p>\n<pre><code class=\"language-groovy\">compileGroovy {\n    groovyOptions.fork = true\n    String path = projectDir.absolutePath\n    groovyOptions.forkOptions.jvmArgs = ['-Dmodule.path=' + path]\n}\n</code></pre>\n"
     },
     {
+        "comment": "This entry in the registry is for the umbrella project for all the AWS plugins from agorapulse. Perhaps this entry is not necessary as each separate plugin also has its own entry?",
         "bintrayPackage": {
             "name": "aws-sdk",
             "repo": "plugins",
             "owner": "agorapulse",
             "desc": "Grails AWS SDK plugin",
             "labels": [
-                
+                "amazon",
+                "aws",
+                "cognito",
+                "dynamodb",
+                "kineses",
+                "s3",
+                "ses",
+                "sns",
+                "sqs",
+                "sts"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
-            "latestVersion": "1.10.74",
-            "updated": "2016-05-03T12:11:35.133Z",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk"
+
             ],
             "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
@@ -486,23 +501,49 @@
     },
     {
         "bintrayPackage": {
-            "name": "aws-sdk-dynamodb",
+            "name": "aws-sdk-cognito",
             "repo": "plugins",
             "owner": "agorapulse",
-            "desc": "Grails AWS SDK DynamoDB plugin",
+            "desc": "Grails AWS SDK Cognito plugin. Uses 'jitpack.io' maven repository.",
             "labels": [
-                
+                "aws",
+                "cognito"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-dynamodb/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-07T07:05:22.409Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-dynamodb"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-cognito"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-dynamodb"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
+        },
+        "documentationUrl": null,
+        "mavenMetadataUrl": null,
+        "readme": "<h1>Grails AWS SDK Cognito Plugin</h1>\n<p>This repo has been migrated to the main <a href=\"https://github.com/agorapulse/grails-aws-sdk\">AWS SDK Grails Plugin</a> repo.</p>\n<p>Here his the <a href=\"https://github.com/agorapulse/grails-aws-sdk/tree/master/grails-aws-sdk-cognito\">latest version of it</a></p>\n"
+    },
+    {
+        "bintrayPackage": {
+            "name": "aws-sdk-dynamodb",
+            "repo": "plugins",
+            "owner": "agorapulse",
+            "desc": "Grails AWS SDK DynamoDB plugin. Uses 'jitpack.io' maven repository.",
+            "labels": [
+                "aws",
+                "dynamodb"
+            ],
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
+            "systemIds": [
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-dynamodb"
+            ],
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
@@ -513,20 +554,21 @@
             "name": "aws-sdk-kinesis",
             "repo": "plugins",
             "owner": "agorapulse",
-            "desc": "Grails AWS SDK Kinesis plugin",
+            "desc": "Grails AWS SDK Kinesis plugin. Uses 'jitpack.io' maven repository.",
             "labels": [
-                
+                "aws",
+                "kinesis"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-kinesis/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-07T07:05:26.687Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-kinesis"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-kinesis"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-kinesis"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
@@ -537,20 +579,21 @@
             "name": "aws-sdk-s3",
             "repo": "plugins",
             "owner": "agorapulse",
-            "desc": "Grails AWS SDK S3 plugin",
+            "desc": "Grails AWS SDK S3 plugin. Uses 'jitpack.io' maven repository.",
             "labels": [
-                
+                "aws",
+                "s3"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-s3/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-08T03:26:29.595Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-s3"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-s3"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-s3"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
@@ -563,18 +606,19 @@
             "owner": "agorapulse",
             "desc": "Grails AWS SDK SES plugin",
             "labels": [
-                
+                "aws",
+                "ses"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-ses/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-07T07:05:33.384Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-ses"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-ses"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-ses"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
@@ -587,18 +631,19 @@
             "owner": "agorapulse",
             "desc": "Grails AWS SDK SNS plugin",
             "labels": [
-                
+                "aws",
+                "sns"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-sns/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-07T07:05:37.324Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-sns"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-sns"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-sns"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
@@ -611,22 +656,48 @@
             "owner": "agorapulse",
             "desc": "Grails AWS SDK SQS plugin",
             "labels": [
-                
+                "aws",
+                "sqs"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk-sqs/issues",
-            "latestVersion": "2.4.8",
-            "updated": "2020-10-08T03:26:38.823Z",
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
             "systemIds": [
-                "org.grails.plugins:aws-sdk-sqs"
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-sqs"
             ],
-            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk-sqs"
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
         "readme": "<h1>Grails AWS SDK SQS Plugin</h1>\n<p>This repo has been migrated to the main <a href=\"https://github.com/agorapulse/grails-aws-sdk\">AWS SDK Grails Plugin</a> repo.</p>\n<p>Here his the <a href=\"https://github.com/agorapulse/grails-aws-sdk/tree/master/grails-aws-sdk-sqs\">latest version of it</a></p>\n"
+    },
+    {
+        "bintrayPackage": {
+            "name": "aws-sdk-sts",
+            "repo": "plugins",
+            "owner": "agorapulse",
+            "desc": "Grails AWS SDK STS plugin",
+            "labels": [
+                "aws",
+                "sts"
+            ],
+            "licenses": [
+                "Apache-2.0"
+            ],
+            "issueTrackerUrl": "https://github.com/agorapulse/grails-aws-sdk/issues",
+            "latestVersion": "2.4.15",
+            "updated": "2022-07-20T06:42:00.000Z",
+            "systemIds": [
+                "com.github.agorapulse.grails-aws-sdk:aws-sdk-sts"
+            ],
+            "vcsUrl": "https://github.com/agorapulse/grails-aws-sdk"
+        },
+        "documentationUrl": null,
+        "mavenMetadataUrl": null,
+        "readme": "<h1>Grails AWS SDK STS Plugin</h1>\n<p>This repo has been migrated to the main <a href=\"https://github.com/agorapulse/grails-aws-sdk\">AWS SDK Grails Plugin</a> repo.</p>\n<p>Here his the <a href=\"https://github.com/agorapulse/grails-aws-sdk/tree/master/grails-aws-sdk-sts\">latest version of it</a></p>\n"
     },
     {
         "bintrayPackage": {
@@ -635,7 +706,8 @@
             "owner": "errbuddy",
             "desc": "Babel.js transformation for Asset-pipeline",
             "labels": [
-                
+                "asset-pipeline",
+                "babel"
             ],
             "licenses": [
                 "BSD 2-Clause"
@@ -644,9 +716,9 @@
             "latestVersion": "2.1.1",
             "updated": "2017-08-08T12:32:15.738Z",
             "systemIds": [
+                "net.errbuddy.plugins:babel-asset-pipeline",
                 "net.errbuddy.plugins:add",
-                "net.errbuddy.plugins:react-asset-pipeline",
-                "net.errbuddy.plugins:babel-asset-pipeline"
+                "net.errbuddy.plugins:react-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/errbuddy/babel-asset-pipeline"
         },
@@ -662,8 +734,7 @@
             "desc": "Gradle plugin for integrating the Bootstrap Framework",
             "labels": [
                 "bootstrap",
-                "font awesome",
-                "gradle"
+                "fontawesome"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -687,7 +758,7 @@
             "owner": "vahid",
             "desc": "Websocket autocomplete/ multi dependency selection plugin for grails 3",
             "labels": [
-                
+                "autocomplete"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -698,35 +769,11 @@
             "systemIds": [
                 "org.grails.plugins:boselecta"
             ],
-            "vcsUrl": "https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/Version"
+            "vcsUrl": "https://github.com/vahidhedayati/grails-boselecta-plugin"
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
         "readme": "<h1>Boselecta plugin</h1>\n<h3>Side note - similar / related projects</h3>\n<ul>\n<li>\n<p><a href=\"https://github.com/vahidhedayati/ajaxdependancyselection\">ajaxdependancyselection</a></p>\n</li>\n<li>\n<p><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin\">grails-boselecta-plugin (this)</a></p>\n</li>\n</ul>\n<p>Grails plugin that uses default WebSocket technology to interact with your domainClasses and produce dependent form / options that depend on one another. The format to define select functionality / auto complete are identical. Auto complete requires additional boolean values to be passed to make it auto complete.</p>\n<h5>Select box dependencies data comes from WebSocket Client running within your application (as part of the plugin)</h5>\n<h5>AutoComplete input areas use HTML5 dataList, data for dataList provided by backend WebSocket Connection.</h5>\n<h4><a href=\"https://www.youtube.com/watch?v=GGB7mtB9nWM\">Walkthrough Video - youtube, Everything you need to know about boselecta</a></h4>\n<p><img src=\"https://raw.githubusercontent.com/vahidhedayati/grails-boselecta-plugin/grails2/documentation/boselecta.png\" alt=\"diagram\" /></p>\n<p><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/More-information\">More information to help with diagram</a></p>\n<p>BoSelecta can be incorporated to an existing grails app running ver 2&gt;+. Supports both resource (pre 2.4) /assets (2.4+) based grails sites.</p>\n<h6>Plugin will work with tomcat 7.0.54 + (inc. 8) running java 1.7+</h6>\n<h6>Dependency</h6>\n<p>Dependency Grails 3:</p>\n<pre><code class=\"language-groovy\">    compile &quot;org.grails.plugins:boselecta:3.0.4&quot;\n</code></pre>\n<p><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/\">codebase for grails 3.X</a></p>\n<p>Dependency Grails 2:</p>\n<pre><code class=\"language-groovy\">\tcompile &quot;:boselecta:0.2&quot; \n</code></pre>\n<p><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/tree/grails2\">codebase for grails 2.X</a></p>\n<p>######<a href=\"https://github.com/vahidhedayati/testbo\">test site for grails 2</a></p>\n<p>######<a href=\"https://github.com/vahidhedayati/testbo3\">test site for grails 3</a></p>\n<p>###Latest updates (after video published):\nA further lock down has been introduced, with the assumption that most people will be looking up domain objects with single dependencies.\nThis means, typically I expect an end user to map from continent to country to city and so on. So its one to one relationship between each object. For this reason the default call now only supports one relation, so:</p>\n<pre><code class=\"language-gsp\">&lt;bo:selecta\n...  \ndomain=&quot;package.domainClass1&quot;\n..\ndomain2=&quot;package.domainClass2&quot;\n..\n/&gt;\n</code></pre>\n<p>domain will be the primary object itself (so a listing of that object, domain2 is the entity that it has that relationship with.</p>\n<p>If you attempt to exceed and use domain3 and on. The plugin will not work. You can from now use selecta2 for those relations with depth</p>\n<pre><code class=\"language-gsp\">&lt;bo:selecta2\ndomainDepth=&quot;4&quot;\n...  \ndomain=&quot;package.domainClass1&quot;\n..\ndomain2=&quot;package.domainClass2&quot;\n..\ndomain3=&quot;package.domainClass3&quot;\n..\ndomain4=&quot;package.domainClass4&quot;\n..\n/&gt;\n</code></pre>\n<h4><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/Testing-plugin\">Testing plugin</a></h4>\n<h4><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/Config.groovy\">Config.groovy overrides</a></h4>\n<h4>[domainDepth explained] (https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/domainDepth-explained)</h4>\n<h5><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/grails-BoSelecta-Plugin-usage\">grails BoSelecta Plugin usage</a></h5>\n<h4><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/JSON-Formatting\">JSON Formatting</a>.</h4>\n<h5><a href=\"https://github.com/vahidhedayati/grails-boselecta-plugin/wiki/What-is-front-end---back-end-WebSocket-connections\">What is front-end / back-end WebSocket connections</a> ?</h5>\n<p>##Examples:</p>\n<h5>Basic example:</h5>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/index.gsp\">Example 1: Connector / selectPrimary into default g:select box. (found in above testbo project)</a></p>\n<ol>\n<li>Initiate a master socket connection, &lt;bo:connect handles all the information flowing back from backend websocket. So this is your main and only connection required on any given page. Take a note of the user and job names, they must match all the calls on this page.</li>\n</ol>\n<p>Both the two code blocks below in one gsp:</p>\n<pre><code class=\"language-gsp\">&lt;bo:connect user=&quot;myuser&quot; job=&quot;job1&quot; /&gt;\n</code></pre>\n<p>Now that we have configured our master listener, lets configure one connection with a relation that is returned to a normal blank select box</p>\n<pre><code class=\"language-gsp\">&lt;form  action=&quot;example5&quot;&gt;\n\n&lt;bo:selecta \nid=&quot;MyCountry1&quot; name=&quot;MyCountry1&quot; job= &quot;job1&quot; user=&quot;myuser&quot; domainDepth=&quot;0&quot; formatting=&quot;JSON&quot;\ndomain='ajaxdependancyselectexample.MyCountry' searchField='countryName' collectField='id'\ndomain2='ajaxdependancyselectexample.MyCity' bindid=&quot;mycountry.id&quot; searchField2='cityName' collectField2='id'\nappendValue='' appendName='Updated' noSelection=&quot;['': 'Please choose Continent']&quot; setId=&quot;MyCity1&quot; /&gt;\n\n&lt;g:select name=&quot;MyCity1&quot; id=&quot;MyCity1&quot; optionKey=&quot;id&quot; optionValue=&quot;cityName&quot; from=&quot;[]&quot; required=&quot;required&quot; noSelection=&quot;['': 'Please choose Country']&quot; /&gt;\n&lt;input type=submit value=go&gt; \n&lt;/form&gt;\n</code></pre>\n<p>If you have used ajaxdependancy selection, a lot of the above input will look familiar.\nYou are now giving the backend the ID of your primary selection MyCountry1, you are telling it what domain is which makes this a primary call and then returns MyCountry.countryName and MyCountry.id to the primary box, you are then setting the setId as MyCity1 and saying domain2 is MyCity and to search/collect cityName/id.</p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/index2.gsp\">Example 2:  Connector / primary / into Secondary into g:select:  (found in above testbo project)</a></p>\n<p>Identical to above, but in this example we iterate over the relations using &lt;bo:select passing domain2 object which be the next object so on the secondary objects there is no domain= value defined.</p>\n<pre><code class=\"language-gsp\">&lt;bo:connect user=&quot;randomUser2&quot; job=&quot;job2&quot; /&gt;\n\n&lt;g:form name=&quot;myForm&quot; action=&quot;example5&quot;&gt;    \n&lt;bo:selecta \n  id=&quot;MyContinent2&quot; name=&quot;MyContinent2&quot; setId=&quot;MyCountry11&quot;\n  job= &quot;job2&quot; user=&quot;randomUser2&quot; domainDepth=&quot;0&quot;    \n  domain='ajaxdependancyselectexample.MyContinent' searchField='continentName' collectField='id'\n  domain2='ajaxdependancyselectexample.MyCountry' bindid=&quot;mycontinent.id&quot; searchField2='countryName'\n  appendValue='' appendName='Updated' collectField2='id' noSelection=&quot;['': 'Please choose Continent']&quot; /&gt;\n\n &lt;bo:selecta id=&quot;MyCountry11&quot; name=&quot;MyCountry11&quot;\n job= &quot;job2&quot; user=&quot;randomUser2&quot; domainDepth=&quot;0&quot; setId=&quot;MyCity11&quot;\n domain2='ajaxdependancyselectexample.MyCity' bindid=&quot;mycountry.id&quot; searchField2='cityName' collectField2='id'\n formatting=&quot;JSON&quot; appendValue=''  appendName='Updated' noSelection=&quot;['': 'Please choose Continent']&quot; /&gt;\n\n &lt;bo:selecta \n name=&quot;MyCity11&quot; id=&quot;MyCity11&quot; job= &quot;job2&quot; user=&quot;randomUser2&quot; domainDepth=&quot;0&quot; setId=&quot;MyShop12&quot; \n domain2='ajaxdependancyselectexample.MyShops' bindid=&quot;mycity.id&quot; searchField2='shopName' collectField2='id'\n appendValue='' appendName='Updated' formatting=&quot;JSON&quot; noSelection=&quot;['': 'Please choose Country 1111']&quot;/&gt;\n\n &lt;g:select \n name=&quot;MyShop12&quot; id=&quot;MyShop12&quot; optionKey=&quot;id&quot; optionValue=&quot;shopName&quot; \n from=&quot;[]&quot; required=&quot;required&quot; noSelection=&quot;['': 'Please choose City']&quot; \n /&gt;\n &lt;g:submitButton name=&quot;submit&quot;/&gt;  \n &lt;/g:form&gt;\n</code></pre>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/definedselectvalues.gsp\">Example 3: Defined pre selected values across multiple objects + randomized user within gsp</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/definedselectvalues2.gsp\">Example 4: Defined pre selected values across less multiple objects + randomized user within controller</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/definedselectvalues3.gsp\">Example 5: Defined pre selected values same as example3 but with JSON return object</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/multidomainexample.gsp\">Example 6: Multiple relationship per domainClass example i.e. object1 has many up to Xth relations with object2 3 4..XXX</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/multimultidomainexample.gsp\">Example 7: applicable to all methods - reuse of the taglib multiple times on the same page</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/noref.gsp\">Example 8: No reference or loose dependency relation between a secondary called object and the next domainClass</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/norefselectionext.gsp\">Example 9: No reference relationship with secondary object that then returns back into a normal relationship object</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/norefprimary.gsp\">Example 10: Primary object with a No reference relationship</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/autoComplete.gsp\">Example 11: Auto complete a few hasMany to a noref relation</a>\nUsing the same Tag to acheive <a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/autoComplete.gsp\">autoComplete</a>\nIn this example (not on actual link, the user is being defined as a variable and reused - this now makes it a dynamic user but same on that one page.</p>\n<p>The difference with this call and select is that as you can see on the first example it has autoComplete=&quot;true&quot; and if this is the primary object then also autoCompletePrimary=&quot;true&quot;, if second object it just needs the first tag. Follow example below.. There are two additional fields hiddenField and jsonField. In autoComplete, the results are returned from html5 dataList. I have added data-value and parse that into the hidden field for jsonField and hiddenField gets set to the or collectField of the value selected. The rest is like above.</p>\n<pre><code class=\"language-gsp\">&lt;% def myuser = bo.randomizeUser('user': 'random1') %&gt;\n\n&lt;bo:connect user=&quot;${myuser}&quot; job=&quot;job3&quot;/&gt;\n\n&lt;form action=&quot;example5&quot;&gt;\n\n&lt;bo:selecta \n    autoComplete=&quot;true&quot; autoCompletePrimary=&quot;true&quot; \n    job=&quot;job3&quot; user=&quot;${myuser}&quot; id=&quot;MyContinent2&quot; name=&quot;MyContinent2&quot; setId=&quot;MyCountry11&quot; \n    hiddenField=&quot;VahidHidden_&quot; jsonField=&quot;VahidJSON_&quot; formatting=&quot;JSON&quot;\n    domain='ajaxdependancyselectexample.MyContinent' searchField='continentName' collectField='id'\n    domain2='ajaxdependancyselectexample.MyCountry' bindid=&quot;mycontinent.id&quot; \n    searchField2='countryName' collectField2='id' /&gt;\n\t\n    &lt;bo:selecta \n\tautoComplete=&quot;true&quot; \n\tjob=&quot;job3&quot; user=&quot;${myuser}&quot; id=&quot;MyCountry11&quot; name=&quot;MyCountry11&quot; \n\thiddenField=&quot;NextHidden_&quot; jsonField=&quot;NextJSON_&quot; formatting=&quot;JSON&quot;\n\tdomain2='ajaxdependancyselectexample.MyCity' bindid=&quot;mycountry.id&quot;\n\tsearchField2='cityName' collectField2='id' setId=&quot;MyCity11&quot; /&gt;\n\t\n    &lt;bo:selecta\n    \tautoComplete=&quot;true&quot;\n\tjob=&quot;job3&quot; user=&quot;${myuser}&quot; formatting=&quot;JSON&quot;\n\tname=&quot;MyCity11&quot; id=&quot;MyCity11&quot; \n\thiddenField=&quot;myHidden_&quot; jsonField=&quot;myJSON_&quot;\n\tdomain2='ajaxdependancyselectexample.MyShops' searchField2='shopName' collectField2='id' \n\tbindid=&quot;mycity.id&quot;  setId=&quot;secondarySearch4&quot; \n\t/&gt;\n\t\n    &lt;bo:selecta \n    \tautoComplete=&quot;true&quot;\n    \tjob= &quot;job121&quot; user=&quot;${myuser }&quot;\tformatting=&quot;JSON&quot; id=&quot;secondarySearch4&quot; name=&quot;NAMEOFBorough&quot;  \n\thiddenField=&quot;myHidden_&quot; jsonField=&quot;myJSON_&quot;\n\tdomain2='ajaxdependancyselectexample.MyBorough' searchField='actualName' collectField='id' \n\tbindid='myborough' value=''\n    /&gt;\n    &lt;input type=submit value=go&gt;\n&lt;/form&gt;\n</code></pre>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/selectautoComplete.gsp\">Example 12: Select To AutoComplete</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/autoCompleteToSelect.gsp\">Example 13:AutoComplete To Select</a></p>\n<p><a href=\"https://github.com/vahidhedayati/testbo/blob/master/grails-app/views/test/selectautoComplete2.gsp\">Example 14: AutoComplete To Select from select to another select</a></p>\n"
-    },
-    {
-        "bintrayPackage": {
-            "name": "bostanio.plugins:airbrake-grails",
-            "repo": "plugins",
-            "owner": "grails",
-            "desc": "Airbrake Client for Grails",
-            "labels": [
-                
-            ],
-            "licenses": [
-                "Apache-2.0"
-            ],
-            "issueTrackerUrl": "https://github.com/cavneb/airbrake-grails/issues",
-            "latestVersion": "1.0.RC1",
-            "updated": "2016-03-31T16:15:11.129Z",
-            "systemIds": [
-                
-            ],
-            "vcsUrl": "https://github.com/cavneb/airbrake-grails"
-        },
-        "documentationUrl": null,
-        "mavenMetadataUrl": null,
-        "readme": "<h1>Airbrake Plugin for Grails</h1>\n<p>This is the notifier plugin for integrating grails apps with <a href=\"http://airbrake.io\">Airbrake</a>.</p>\n<p>When an uncaught exception occurs, Airbrake will POST the relevant data to the Airbrake server specified in your environment.</p>\n<h2>Installation &amp; Configuration</h2>\n<p>Add the following to your <code>BuildConfig.groovy</code></p>\n<pre><code>compile &quot;:airbrake:0.9.4&quot;\n</code></pre>\n<p>Once the plugin is installed, you need to provide your Api Key in <code>Config.groovy</code> file:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.apiKey = 'YOUR_API_KEY'\n</code></pre>\n<h2>Usage</h2>\n<p>Once you have installed and configured the plugin there is nothing else to do. Uncaught exceptions will be logged by log4j and those errors will be reported to Airbrake. However, the plugin also exposes a few other ways to send errors to airbrake.</p>\n<h3>Logging Errors with Exceptions</h3>\n<p>Manually logging messages at the error level and including an Exception triggers an error notification to airbrake:</p>\n<pre><code class=\"language-groovy\">class SomeController\n\tdef someAction() {\n\t\ttry {\n\t\t\tsomethingThatThrowsAnException()\n\t\t} catch(e) {\n\t\t\tlog.error('An error occured', e)\n\t\t}\n\t}\n</code></pre>\n<p>(See the section below on configuring the plugin to including errors without exceptions.)</p>\n<h3>AirbakeService</h3>\n<p>The plugin also exposes an <code>airbrakeService</code> which can be dependency injected into your Grails classes. The service allows you to send error notifications directly to Airbrake without logging anything to log4j. It has a <code>notify</code> method that takes a <code>Throwable</code> parameter and an optional Map of arguemnts. The next example shows both in use:</p>\n<pre><code class=\"language-groovy\">class SomeController\n\tdef airbrakeService\n\t\n\tdef someAction() {\n\t\ttry {\n\t\t\tsomethingThatThrowsAnException()\n\t\t} catch(e) {\n\t\t\tairbrakeService.notify(e, [errorMessage: 'An error occurred'])\n\t\t}\n\t}\n\n\tdef anotherAction() {\n\t\tif (somethingWentWrong()) {\n\t\t\tairbrakeService.notify(null, [errorMessage: 'Something went wrong'])\n\t\t}\n\t}\n</code></pre>\n<h2>Advanced Configuration</h2>\n<p>The Api Key is the minimum requirement to report errors to Airbrake. However, the plugin supports several other configuration options. The full list of configuration options is:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.apiKey\ngrails.plugins.airbrake.enabled\ngrails.plugins.airbrake.env\ngrails.plugins.airbrake.includeEventsWithoutExceptions\ngrails.plugins.airbrake.paramsFilteredKeys\ngrails.plugins.airbrake.sessionFilteredKeys\ngrails.plugins.airbrake.cgiDataFilteredKeys\ngrails.plugins.airbrake.host\ngrails.plugins.airbrake.port\ngrails.plugins.airbrake.secure\ngrails.plugins.airbrake.async\ngrails.plugins.airbrake.asyncThreadPoolSize\ngrails.plugins.airbrake.stackTraceFilterer\ngrails.plugins.airbrake.excludes\n</code></pre>\n<h3>Enabling/Disabling Notifications</h3>\n<p>By default all errors are sent to Airbrake. However, you can disable error notifications (essentially disabling the plugin) by setting <code>grails.plugins.airbrake.enabled = false</code>. For example to disable error notificaitons in development and test environments you might have the following in <code>Config.groovy</code>:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.apiKey = 'YOUR_API_KEY'\nenvironments {\n\tdevelopment {\n\t\tgrails.plugins.airbrake.enabled = false\n\t}\n\ttest {\n\t\tgrails.plugins.airbrake.enabled = false\n\t}\n</code></pre>\n<h4>Disabling Notifications by Exception Type</h4>\n<p>For example, to disable notifications caused by <code>IllegalArgumentException</code> and <code>IllegalStateException</code>, configure</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.excludes = ['java.lang.IllegalArgumentException', 'java.lang.IllegalStateException']\n</code></pre>\n<p>each entry in the list will be converted to a <code>Pattern</code> and matched against the exception class name, so the following\nwould also exclude these two exceptions:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.excludes = ['java.lang.Illegal.*Exception']\n</code></pre>\n<h4>Runtime Enabling/Disabling</h4>\n<p>If you wish to enable/disable notifications at runtime you have a couple of options</p>\n<ul>\n<li>Call the service method <code>airbrakeService.setEnabled(boolean enabled)</code></li>\n<li>Invoke the <code>setEnabled</code> action of <code>AirbrakeTestController</code>. This action expects a single parameter either <code>enabled=true</code> or <code>enabled=false</code></li>\n</ul>\n<h3>Setting the Environment</h3>\n<p>By default, the environment name used in Airbrake will match that of the current Grails environment. To change this default, set the env property:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.env = grails.util.Environment.current.name[0..0] // Airbrake env name changed from default value of Development/Test/Production to D/T/P\n</code></pre>\n<h3>Including all events logged at the Error level</h3>\n<p>By default only uncaught errors or errors logged with an exception are reported to Airbrake. It is often convenient to loosen that restriction so that all messages logged at the <code>Error</code> level are reported to Airbrake. This often most useful in <code>src/java</code> or <code>src/groovy</code> classes that can more easily have a log4j logger than get accees to the dependency injected <code>airbrakeService</code>.</p>\n<p>With the following line in <code>Config.groovy</code>:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.includeEventsWithoutExceptions = true\n</code></pre>\n<p>then logged errors get reported to Airbrake:</p>\n<pre><code class=\"language-groovy\">@Log4j\nclass SomeGroovyClass {\n\tdef doSomething() {\n\t\tif (somethingWentWrong()) {\n\t\t\tlog.error('Something went wrong')\n\t\t}\n\t}\n}\n</code></pre>\n<p>Note: It might be reasonable to have this setting true by default but for backwards compatibility with previous versions of te plugin the default is false.</p>\n<h3>Filtering Parameters sent to Airbrake</h3>\n<p>To prevent certain parameters from being sent to Airbrake you can configure a list of parameter names to filter out. The configuration settings <code>paramsFilteredKeys</code>, <code>sessionFilteredKeys</code> and <code>cgiFilteredKeys</code> filter the params, session and cgi data sent to Airbrake.\nFor example to prevent any web request parameter named 'password' from being included in the notification to Airbrake you would use the following configuration:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.paramsFilteredKeys = ['password']\n</code></pre>\n<p>Each configuration option also supports regular expression matching on the keys. For example the following configuration would prevent all session data from being sent to Airbrake:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.sessionFilteredKeys = ['.*']\n</code></pre>\n<h3>Custom Airbrake Host, Port and Scheme</h3>\n<p>If you are running the Airbrake server locally (or a clone thereof, e.g. Errbit), you will need to customise the server URL, port, scheme, etc.\nFor example to change the server host and port, add the following configuration parameters:</p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.host = 'errbit.example.org'\ngrails.plugins.airbrake.port = 8080\n</code></pre>\n<h3>Adding Custom Data to Error Notifications</h3>\n<h3>Supplying User Data</h3>\n<p>Airbrake allows certain User data to be supplied with the notice. To set the current users data to be included in all notifications use the <code>airbrakeService.addNoticeContext</code> method to set a map of userData.\nThe supported keys are <code>id</code>, <code>name</code>, <code>email</code> and <code>username</code></p>\n<pre><code class=\"language-groovy\">airbrakeService.addNoticeContext(id: '1234', name: 'Bugs Bunny', email: 'bugs@acme.com', username: 'bugs')\n</code></pre>\n<p>In most web apps the simplest way to provide this context is in a Grails filter. For example if you are using <code>SpringSecurity</code> add the following <code>AirbrakeFilter.groovy</code> in <code>grails-app/conf</code></p>\n<pre><code class=\"language-groovy\">class AirbrakeFilters {\n    def airbrakeService\n    def springSecurityService\n\n    def filters = {\n        all(uri: '/**') {\n            before = {\n                def user = springSecurityService.currentUser\n                if (user) {\n                   airbrakeService.addNoticeContext(user: [id: user.id, name: user.name, email: user.email, username: user.username ])\n                }\n            }\n        }\n    }\n}\n</code></pre>\n<h2>Synchronous/Asynchronous notifications</h2>\n<p>By default, notifications are sent to Airbrake asynchronously using a thread-pool of size 5. To change the size of this thread\npool set the following config parameter:</p>\n<pre><code class=\"language-groovy\">// double the size of the pool\ngrails.plugins.airbrake.asyncThreadPoolSize = 10\n</code></pre>\n<p>To have the notifications sent synchronously, set the async parameter to false:</p>\n<pre><code class=\"language-groovy\">// send notifications synchronously\ngrails.plugins.airbrake.async = false\n</code></pre>\n<h3>Custom Asynchronous Handler</h3>\n<p>To send the notifications asynchronously using a custom handler, use the async configuration option.\nThis configuration takes a closure with two parameters the <code>Notice</code> to send and the <code>grailsApplication</code>. The asynchronous handler should simply call <code>airbrakeService.sendNotice(notice)</code> to deliver the notification.</p>\n<p>This plugin does not introduce a default choice for processing notices asynchronously. You should choose a method that suits your application.\nYou could just create a new thread or use a scheduler/queuing plugin such as <a href=\"http://grails.org/plugin/quartz\">Quartz</a> or <a href=\"http://grails.org/plugin/jesque\">Jesque</a></p>\n<p>For example if you are using the Quartz plugin you can send notifications asynchronously using the following setting in <code>Config.groovy</code></p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.async = { notice, grailsApplication -&gt;\n    AirbrakeNotifyJob.triggerNow(notice: notice)\n}\n</code></pre>\n<p>and the <code>AirbrakeNotifyJob</code> is defined in <code>grails-app\\jobs</code> something like this:</p>\n<pre><code class=\"language-groovy\">class AirbrakeNotifyJob {\n    def airbrakeService\n\n    def execute(JobExecutionContext context) {\n        Notice notice = context.mergedJobDataMap.notice\n        if (notice) {\n            airbrakeService.sendNotice(notice)\n        }\n    }\n}\n</code></pre>\n<h3>Stack Trace Filtering</h3>\n<p>By default all stack traces are filtered using an instance of <code>org.codehaus.groovy.grails.exceptions.DefaultStackTraceFilterer</code> to remove common Grails and java packages.\nTo provide custom stack trace filtering simple configure an instance of a class that implements the interface <code>org.codehaus.groovy.grails.exceptions.StackTraceFilterer</code> in <code>Config.groovy</code></p>\n<pre><code class=\"language-groovy\">grails.plugins.airbrake.stackTraceFilterer = new MyCustomStackTraceFilterer()\n</code></pre>\n<h2>Compatibility</h2>\n<p>This plugin is compatible with Grails version 2.0 or greater. A backport to Grails 1.3 is available on the [grails-1.3 branch] (https://github.com/cavneb/airbrake-grails/tree/grails-1.3).</p>\n<h2>Release Notes</h2>\n<ul>\n<li>0.7 - 2012/09/21\n<ul>\n<li>Added support for filtering parameters, session and cgiData. #2</li>\n</ul>\n</li>\n<li>0.7.1 - 2012/09/21\n<ul>\n<li>Change supported Grails version to 2.0.0. #3</li>\n</ul>\n</li>\n<li>0.7.2 - 2012/09/24\n<ul>\n<li>Added User Agent, Hostname and user data to notifications</li>\n</ul>\n</li>\n<li>0.8 - 2012/10/16\n<ul>\n<li>Simpler configuration (Breaking change)</li>\n<li>Default notification environment to current Grails environment. #9</li>\n<li>Support for notifying caught exceptions. #15</li>\n<li>Support for notifying all messages logged at the error level (with or without exceptions)</li>\n<li>Simpler api for providing user data</li>\n<li>Full class names in stacktrace. #11</li>\n</ul>\n</li>\n<li>0.8.1 - 2012/10/19\n<ul>\n<li>Better error message for uncaught exceptions. #18</li>\n</ul>\n</li>\n<li>0.9.0 - 2012/10/29\n<ul>\n<li>Support for sending notifications to Airbrake asynchronously</li>\n<li>Added method to AirbrakeService set notification context information that will be used for any reported errors</li>\n<li>Simpler api to provide User Data. No need to implement UserDataService instead just set the context. (Breaking Change)</li>\n<li>All request headers now included when reporting an error.</li>\n</ul>\n</li>\n<li>0.9.1 - 2012/11/30\n<ul>\n<li>Notifications sent to Airbrake asynchronously by default using a thread pool of configurable size #20</li>\n<li>By default stack traces are filtered #19</li>\n<li>New configuration option to support custom stack trace filtering</li>\n<li>New configuration options for filtering params, session and cgi data independently</li>\n</ul>\n</li>\n<li>0.9.2 - 2013/1/19\n<ul>\n<li>Support for Grails 2.2 and Groovy 2.0 #27</li>\n</ul>\n</li>\n<li>0.9.3 - 2013/05/10\n<ul>\n<li>New feature to enable/disable notification send while the plugin is running #31</li>\n<li>New configuration option to filter exceptions by name or pattern #34</li>\n<li>Bug fix. Don't send notifications synchronously by default #26</li>\n<li>Bug fix. Handle empty backtrace more gracefully for Errbit #33</li>\n<li>Thanks to @domurtag for all the fixes</li>\n</ul>\n</li>\n<li>0.9.4 - 2013/06/25\n<ul>\n<li>Bug fix. AirbrakeNotifier.notify no longer throws under any circumstance.</li>\n</ul>\n</li>\n</ul>\n<h2>Contributing</h2>\n<ol>\n<li>Fork it</li>\n<li>Create your feature branch (<code>git checkout -b my-new-feature</code>)</li>\n<li>Commit your changes (<code>git commit -am 'Added some feature'</code>)</li>\n<li>Push to the branch (<code>git push origin my-new-feature</code>)</li>\n<li>Create new Pull Request</li>\n</ol>\n<h1>Kudos</h1>\n<p>The origin version of this plugin was written by Phuong LeCong (<a href=\"https://github.com/plecong/grails-airbrake\">https://github.com/plecong/grails-airbrake</a>).\nSince then it has undergone significant refactoring and updates inspired by the Ruby Airbrake gem (<a href=\"https://github.com/airbrake/airbrake\">https://github.com/airbrake/airbrake</a>)</p>\n"
     },
     {
         "bintrayPackage": {
@@ -759,7 +806,7 @@
             "owner": "longwa",
             "desc": "Grails build-test-data plugin",
             "labels": [
-                
+                "testing"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -768,6 +815,7 @@
             "latestVersion": "4.0.0",
             "updated": "2019-12-20T01:02:42.869Z",
             "systemIds": [
+                "io.github.longwa:build-test-data",
                 "org.grails.plugins:build-test-data"
             ],
             "vcsUrl": "https://github.com/longwa/build-test-data"
@@ -783,7 +831,7 @@
             "owner": "grails",
             "desc": "Grails Cache Plugin",
             "labels": [
-                
+                "cache"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -807,7 +855,8 @@
             "owner": "grails",
             "desc": "Provides an ehcache implementation of the cache plugin",
             "labels": [
-                
+                "cache",
+                "ehcache"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -820,7 +869,7 @@
             ],
             "vcsUrl": "https://github.com/grails-plugins/grails-cache-ehcache"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-cache-ehcache/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-cache-ehcache/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/grails-plugins/grails-cache-ehcache\"><img src=\"https://travis-ci.org/grails-plugins/grails-cache-ehcache.svg\" alt=\"Build Status\" /></a></p>\n<h1>Grails Cache Ehcache Plugin</h1>\n<p>Makes Ehcache the cache implementation for the <a href=\"https://github.com/grails-plugins/grails-cache\">Grails Cache Plugin</a></p>\n<h2>Grails 3</h2>\n<p>See https://plugins.grails.org/plugin/grails/cache-ehcache and <a href=\"http://grails-plugins.github.io/grails-cache-ehcache/latest/\">Documentation</a></p>\n<h2>Grails 2</h2>\n<p>See https://grails.org/plugin/cache-ehcache and <a href=\"http://grails-plugins.github.io/grails-cache-ehcache/\">Documentation</a></p>\n<h2>Branches</h2>\n<p>The current master branch is for 3.x versions of the plugin compatible with Grails 3. There is a 1.x branch for on-going maintenance of 1.x versions of the plugin compatible with Grails 2. Please submit any pull requests to the appropriate branch. Changes to the 1.x branch will be merged into the master branch if appropriate.</p>\n"
     },
@@ -831,7 +880,7 @@
             "owner": "mkobel",
             "desc": "The guava cache provides a simple in memory cache with maximal capacity and TTL.",
             "labels": [
-                
+                "cache"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -855,7 +904,7 @@
             "owner": "grails",
             "desc": "Improve your application performance with browser caching, with easy ways to set caching headers\nin controller responses",
             "labels": [
-                
+                "cache"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -888,8 +937,8 @@
             "latestVersion": "2.0.2",
             "updated": "2016-03-31T13:31:54.830Z",
             "systemIds": [
-                "org.grails.plugins:grails-cascade-validation",
-                "org.grails.plugins:cascade-validation"
+                "org.grails.plugins:cascade-validation",
+                "org.grails.plugins:grails-cascade-validation"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-cascade-validation"
         },
@@ -918,7 +967,7 @@
             ],
             "vcsUrl": "https://github.com/grails/gorm-cassandra"
         },
-        "documentationUrl": null,
+        "documentationUrl": "https://gorm.grails.org/latest/cassandra/manual/",
         "mavenMetadataUrl": null,
         "readme": "<h1>GORM for Cassandra</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/\">GORM</a> for the Cassandra Column Database.</p>\n<p>For more information see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/cassandra/manual\">Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/cassandra/api\">API</a></li>\n<li><a href=\"https://grails.org/plugins.html#plugin/cassandra\">Grails Plugin</a></li>\n<li><a href=\"https://travis-ci.org/grails/gorm-cassandra\"><img src=\"https://travis-ci.org/grails/gorm-cassandra.svg?branch=master\" alt=\"Build Status\" /></a></li>\n</ul>\n<p>For the current development version see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/cassandra/manual\">Beta Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/cassandra/api\">Beta API</a></li>\n</ul>\n"
     },
@@ -929,7 +978,7 @@
             "owner": "stefanogualdi",
             "desc": "CKeditor web WYSIWYG editor integration plugin.",
             "labels": [
-                
+                "ckeditor"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -944,40 +993,17 @@
         },
         "documentationUrl": "https://stefanogualdi.github.io/grails-ckeditor/",
         "mavenMetadataUrl": null,
-        "readme": "<h1>CKeditor plugin for Grails</h1>\n<p>The user guide can be found here: <a href=\"http://stefanogualdi.github.com/grails-ckeditor/\">Documentation</a></p>\n"
-    },
-    {
-        "bintrayPackage": {
-            "name": "clojure",
-            "repo": "plugins",
-            "owner": "grails",
-            "desc": "Grails clojure plugin",
-            "labels": [
-                
-            ],
-            "licenses": [
-                "Apache-2.0"
-            ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/clojure/issues",
-            "latestVersion": "2.0.0.RC2",
-            "updated": "2016-10-03T14:35:20.851Z",
-            "systemIds": [
-                
-            ],
-            "vcsUrl": "https://github.com/grails-plugins/clojure"
-        },
-        "documentationUrl": "https://grails-plugins.github.io/clojure/",
-        "mavenMetadataUrl": null,
-        "readme": null
+        "readme": "<h1>CKeditor plugin for Grails</h1>\n<p>The user guide can be found here: <a href=\"https://stefanogualdi.github.io/grails-ckeditor/\">Documentation</a></p>\n"
     },
     {
         "bintrayPackage": {
             "name": "cmeditor",
             "repo": "maven",
             "owner": "frnktrgr",
-            "desc": "CMEditor is a simple way to use the popular CodeMirror web editor in grails applications. You can use it to edit pretty much anything that can be mapped to a file-like object. I.e. something with a filename and text-content. If your model requires additional fields this is supported, too.     For example managing your library could be done by mapping filename to \"Frank Tr\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffdger - CMEditor\". The tabbed editor then could manage everything: Author, title, publication year and - of course - the books content in a nice-to-use CodeMirror editor. You could even edit multiple books simultaneously.     Check out our demo grails project at https://github.com/RRZE-PP/grails-cmeditor-demo.     ",
+            "desc": "CMEditor is a simple way to use the popular CodeMirror web editor in grails applications.",
             "labels": [
-                
+                "cmeditor",
+                "codemirror"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -999,26 +1025,24 @@
             "name": "coffee-asset-pipeline",
             "repo": "asset-pipeline",
             "owner": "bertramlabs",
-            "desc": "Easily process coffee-script files with the asset-pipeline plugin. Package includes both jvm coffee runtime as well as the ability to use the coffeescript npm module if detected.",
+            "desc": "Easily process CoffeeScript files with the asset-pipeline plugin. Package includes both jvm coffee runtime as well as the ability to use the coffeescript npm module if detected.",
             "labels": [
                 "asset-pipeline",
-                "assets",
-                "coffee",
-                "resources"
+                "coffeescript"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
-            "latestVersion": "3.3.1",
-            "updated": "2020-09-24T17:05:47.066Z",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:50.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:coffee-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/coffee-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -1028,9 +1052,7 @@
             "owner": "virtualdogbert",
             "desc": "Grails command plugin",
             "labels": [
-                "command",
-                "command objects",
-                "parmeter checking",
+                "command-objects",
                 "validation"
             ],
             "licenses": [
@@ -1055,21 +1077,24 @@
             "owner": "bertramlabs",
             "desc": "Provides Compass/SCSS Build support using the jruby runtime. Any compass project can be adjusted to be built by the asset-pipeline and used in applications.",
             "labels": [
-                
+                "asset-pipeline",
+                "compass",
+                "scss",
+                "css"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
-            "latestVersion": "3.3.1",
-            "updated": "2020-09-24T17:13:14.345Z",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:14.345Z",
             "systemIds": [
                 "com.bertramlabs.plugins:compass-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline.git"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/compass-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -1079,7 +1104,9 @@
             "owner": "sheehan",
             "desc": "A web-based Groovy console for interactive runtime application management and debugging.",
             "labels": [
-                
+                "console",
+                "management",
+                "debugging"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1103,7 +1130,7 @@
             "owner": "puravida-software",
             "desc": "Consulta el nombre registrado en la AEAT para un NIF dado",
             "labels": [
-                
+
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1127,7 +1154,8 @@
             "owner": "grails",
             "desc": "Provides JSON and XML converters",
             "labels": [
-                
+                "json",
+                "xml"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1151,12 +1179,7 @@
             "owner": "ctoestreich",
             "desc": "Grails Cookie Plugin",
             "labels": [
-                "cookie",
-                "cookie-service",
-                "cookieservice",
-                "grails",
-                "request",
-                "response"
+                "cookies"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1165,8 +1188,8 @@
             "latestVersion": "2.0.5",
             "updated": "2016-04-21T01:59:54.523Z",
             "systemIds": [
-                "org.grails.plugins:grails-cookie",
-                "org.grails.plugins:cookie"
+                "org.grails.plugins:cookie",
+                "org.grails.plugins:grails-cookie"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-cookie"
         },
@@ -1175,13 +1198,15 @@
         "readme": "<h1>Grails Cookie Plugin</h1>\n<p><a href=\"https://api.travis-ci.org/Grails-Plugin-Consortium/grails-cookie\"><img src=\"https://api.travis-ci.org/Grails-Plugin-Consortium/grails-cookie.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>This plugin makes dealing with cookies easy. Provides an injectable service and tag to easily get, set, and delete cookies with one line.</p>\n<p>It's <a href=\"http://tools.ietf.org/html/rfc6265\">RFC 6265</a> compliant.</p>\n<h2>Installation</h2>\n<p>To install the cookie plug-in just add to <code>build.gradle</code>:</p>\n<pre><code class=\"language-groovy\">    \n    compile 'org.grails.plugins:grails-cookie:2.0.3'\n    \n</code></pre>\n<h2>Configuration</h2>\n<p>You can configure in <code>Config.groovy</code> or <code>application.yml</code> how long the default cookie age will be (in seconds) when not explicitly supplied while setting a cookie.</p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.cookieage.default = 86400 // if not specified default in code is 30 days\n</code></pre>\n<h2>Usage</h2>\n<p>You have two ways to work with cookies:</p>\n<ul>\n<li>The cookie plug-in extends the <code>request</code> and <code>response</code> objects found in controllers, filters, etc to allow the following.</li>\n<li>The cookie plug-in provides a <a href=\"./grails-app/services/grails/plugin/cookie/CookieService.groovy\">CookieService</a> that can be used anywhere in your Grails application.</li>\n</ul>\n<p>Example of setting a new cookie:</p>\n<pre><code class=\"language-groovy\">// This sets a cookie with the name `username` to the value `cookieUser123` with a expiration set to a week, defined in seconds\nresponse.setCookie('username', 'cookieUser123', 604800)\n// will use default age from Config (or 30 days if not defined)\nresponse.setCookie('username', 'cookieUser123')\n\n// using service\ndef cookieService // define field for DI\n...\ncookieService.setCookie('username', 'cookieUser123', 604800)\n</code></pre>\n<p>To get the cookie value:</p>\n<pre><code class=\"language-groovy\">request.getCookie('username') // returns 'cookieUser123'\n\n// using service\ndef cookieService // define field for DI\n...\ncookieService.getCookie('username') // returns 'cookieUser123'\n</code></pre>\n<p>To delete the cookie (actually it set new expired cookie with same name):</p>\n<pre><code class=\"language-groovy\">response.deleteCookie('username') // deletes the 'username' cookie\n// using service\ndef cookieService // define field for DI\n...\ncookieService.deleteCookie('username')\n</code></pre>\n<p>All this methods has other signatures and you can find all of them in <a href=\"./grails-app/services/grails/plugin/cookie/CookieService.groovy\">CookieService</a> JavaDoc's.</p>\n<p>You can check out <a href=\"https://github.com/stokito/grails-cookie-demo\">Demo project</a> and also you can find details of implementation in <a href=\"./src/test/groovy/grails/plugin/cookie/CookieRequestSpec.groovy\">CookieRequestSpec</a> and <a href=\"./src/test/groovy/grails/plugin/cookie/CookieResponseSpec.groovy\">CookieResponseSpec</a>.</p>\n<h2>Configuration</h2>\n<p>You can configure default values of attributes in <code>Config.groovy</code>.</p>\n<h3>Default Max Age</h3>\n<p>Default expiration age for cookie in seconds. <code>Max-Age</code> attribute, integer.</p>\n<p>If it has value <code>-1</code> cookie will not stored and removed after browser close.</p>\n<p>If it has null value or unset, will be used 30 days, i.e. <code>2592000</code> seconds.</p>\n<p>Can't has value <code>0</code>, because it means that cookie should be removed.</p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.cookieage.default = 360 * 24 * 60 * 60\n</code></pre>\n<h3>Default Path</h3>\n<p>Default path for cookie selection strategy, string.</p>\n<ul>\n<li>'context' - web app context path, i.e. <code>grails.app.context</code> option in <code>Config.groovy</code></li>\n<li>'root' - root of server, i.e. '/'</li>\n<li>'current' - current directory, i.e. controller name</li>\n</ul>\n<p>If default path is null or unset, it will be used 'context' strategy</p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.path.defaultStrategy = 'context'\n</code></pre>\n<h3>Default Secure</h3>\n<p>Default secure cookie param. Secure cookie available only for HTTPS connections. <code>Secure</code> attribute, boolean.\nIf default secure is null or unset, it will set all new cookies as secure if current connection is secure</p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.secure.default = null\n</code></pre>\n<h3>Default HTTP Only</h3>\n<p>Default HTTP Only param that denies accessing to JavaScript's <code>document.cookie</code>.</p>\n<p>If null or unset will be <code>true</code></p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.httpOnly.default = true\n</code></pre>\n<p>You can find details of implementation in <a href=\"./src/test/groovy/grails/plugin/cookie/CookieServiceDefaultsSpec.groovy\">CookieServiceDefaultsSpec</a>.</p>\n<h3>External Config</h3>\n<p>If you use property files to inject values to plugins at runtime.  This is now supported as of version 1.0.2.  This means that inside your external <code>foo.properties</code> file you can specify the following.</p>\n<pre><code class=\"language-groovy\">grails.plugins.cookie.httpOnly.default=true\n</code></pre>\n<p>The string value will correctly be treated as a boolean.</p>\n<h2>Changelog</h2>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases\">All releases</a></p>\n<h3>v2.0.5 For Grails 3.0</h3>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases/tag/v2.0.5\">Source</a></p>\n<ul>\n<li>Bug fix for NPE on some find methods in groovy (Even though supposed to be null safe http://stackoverflow.com/questions/6866253/groovy-give-npe-on-list-find-call-but-only-after-a-period-of-time)</li>\n</ul>\n<h3>v2.0.3 For Grails 3.0</h3>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases/tag/v2.0.3\">Source</a></p>\n<ul>\n<li>Missed exclude for test service</li>\n</ul>\n<h3>v2.0.2 For Grails 3.0</h3>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases/tag/v2.0.2\">Source</a></p>\n<ul>\n<li>Syncing extension and plugin versions</li>\n</ul>\n<h3>v2.0.1 For Grails 3.0</h3>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases/tag/v2.0.1\">Source</a></p>\n<ul>\n<li>Testing for mocking of service which was causing issues in grails 3.0.10</li>\n</ul>\n<h3>v2.0 For Grails 3.0</h3>\n<p><a href=\"https://github.com/grails-plugin-consortium/grails-cookie/releases/tag/v2.0\">Source</a></p>\n<h3>v1.4 For Grails 2.4</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v1.4\">Source</a></p>\n<ul>\n<li>Minimal Grails version 2.4</li>\n</ul>\n<h3>v1.2 Fixed bug with <code>path.defaultStrategy</code> option</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v1.2\">Source</a></p>\n<ul>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/35\">#35</a> option <code>grails.plugins.cookie.path.defaultStrategy</code> doesn't work.</li>\n<li>Minimal Grails version 2.2.0. But tests of plugin itself will failed. To run them use command <code>./grailsw test-app</code> that uses wrapper with Grails 2.4</li>\n<li>Minimal Java version is downgraded to 6</li>\n</ul>\n<h3>v1.1.0 Fixed bug with defaults not configured in Config</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v1.1.0\">Source</a></p>\n<ul>\n<li>Minimal Grails version 2.4.0. Plugin probably should work with early versions of Grails but init tests require v2.4.0</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/32\">#32</a> Add ability to externalize configuration by changing check for boolean from <code>instanceof Boolean</code> to <code>toBoolean()</code> which will correctly address boolean <code>false</code> and string <code>&quot;false&quot;</code> properties</li>\n</ul>\n<h3>v1.0.1 Fixed bug with defaults not configured in Config</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v1.0.1\">Source</a></p>\n<ul>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/30\">#30</a> Default path strategy is 'context' and <code>grails.app.context</code> used null instead of actual context</li>\n</ul>\n<h3>v1.0 Production ready version</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v1.0\">Source</a></p>\n<ul>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/17\">#17</a> Since v0.1 all deprecated things was removed:\n* Tag <code>&lt;cookie:get/&gt;</code>. Use standard <code>&lt;g:cookie/&gt;</code> tag instead.\n* Methods <code>get()</code>, <code>set()</code>, <code>delete()</code> from <code>CookieService</code>. They are replaced with corresponding <code>getCookie()</code>,  <code>setCookie()</code>, <code>deleteCookie()</code>.</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/19\">#19</a> All cookies should be Version 1 (by RFC 2109) cookie specifications</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/22\">#22</a> Support of cookie attributes</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/10\">#10</a> Improved delete cookie method.  Method delete cookie now can takes a domain name</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/28\">#28</a> <code>setCookie()</code> and <code>deleteCookie()</code> should return added cookie</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/25\">#25</a> Make default <code>path</code>, <code>secure</code> and <code>httpOnly</code> configurable and more intelligent  enhancement</li>\n</ul>\n<h3>v0.60 Last release with deprecated taglib and methods in service</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v0.6\">Source</a></p>\n<ul>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/3\">#3</a> Fixed <code>deleteCookie</code> not works in <code>response</code></li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/16\">#16</a> added tests</li>\n<li><a href=\"https://github.com/stokito/grails-cookie/issues/17\">#17</a> Since v0.5 few things was deprecated and will be removed in version v1.0:\n* Tag <code>&lt;cookie:get/&gt;</code>. Use standard <code>&lt;g:cookie/&gt;</code> tag instead.\n* Methods <code>get()</code>, <code>set()</code>, <code>delete()</code> from <code>CookieService</code>. They are replaced with corresponding <code>getCookie()</code>,  <code>setCookie()</code>, <code>deleteCookie()</code>.</li>\n</ul>\n<h3>v0.3</h3>\n<p><a href=\"https://github.com/stokito/grails-cookie/releases/tag/v0.3\">Source</a></p>\n<p>In the v0.3 release a big issue was fixed that now sets the cookie's path to the root <code>/</code> context.\nOtherwise it was setting the path to the same as the controller/service that triggered it.\nMost users I believe will want this behavior. If setting the path is desired, that can be accommodated.\nPlease contact me or do a pull request if you'd like that.</p>\n"
     },
     {
+        "deprecated": "It seems that this project is continued in a fork by double16 and published at the same maven coordinates. This entry in the registry should probably be removed to avoid confusion.",
         "bintrayPackage": {
             "name": "cookie-session",
             "repo": "maven",
             "owner": "benlucchesi",
             "desc": "Grails cookiesession plugin",
             "labels": [
-                
+                "cookies",
+                "http-session"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1205,7 +1230,8 @@
             "owner": "double16",
             "desc": "The Cookie Session plugin enables grails applications to store session data in http cookies between requests instead of in memory on the server.",
             "labels": [
-                
+                "cookies",
+                "http-session"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1229,9 +1255,7 @@
             "owner": "sachinverma",
             "desc": "Grails csv plugin",
             "labels": [
-                "csv",
-                "grails",
-                "grails3"
+                "csv"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1255,7 +1279,6 @@
             "owner": "ctoestreich",
             "desc": "Grails CXF Plugin",
             "labels": [
-                "apache",
                 "cxf",
                 "soap"
             ],
@@ -1266,8 +1289,8 @@
             "latestVersion": "3.1.2",
             "updated": "2018-05-04T00:36:38.345Z",
             "systemIds": [
-                "org.grails.plugins:grails-cxf",
-                "org.grails.plugins:cxf"
+                "org.grails.plugins:cxf",
+                "org.grails.plugins:grails-cxf"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-cxf"
         },
@@ -1282,10 +1305,9 @@
             "owner": "ctoestreich",
             "desc": "Grails CXF Client Plugin",
             "labels": [
-                "apache",
-                "client",
                 "cxf",
-                "soap"
+                "soap",
+                "client"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1294,8 +1316,8 @@
             "latestVersion": "3.0.7",
             "updated": "2016-04-11T19:21:38.732Z",
             "systemIds": [
-                "org.grails.plugins:grails-cxf-client",
-                "org.grails.plugins:cxf-client"
+                "org.grails.plugins:cxf-client",
+                "org.grails.plugins:grails-cxf-client"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-cxf-client"
         },
@@ -1310,7 +1332,9 @@
             "owner": "grails",
             "desc": "Grails database-migration plugin",
             "labels": [
-                
+                "liquibase",
+                "migration",
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1328,13 +1352,14 @@
         "readme": null
     },
     {
+        "comment": "There is no published version that is compatible with Grails >= 3 (0.3 is not published as of this writing)",
         "bintrayPackage": {
             "name": "daysofweek",
             "repo": "daysofweek",
             "owner": "vahid",
-            "desc": "Grails Days Of week plugin using ICU4J libraries to work out internationl calendar week days",
+            "desc": "Grails Days Of week plugin using ICU4J libraries to work out international calendar week days",
             "labels": [
-                
+                "calendar"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1358,7 +1383,7 @@
             "owner": "grails",
             "desc": "Grails db-reverse-engineer plugin",
             "labels": [
-                
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1376,13 +1401,14 @@
         "readme": null
     },
     {
+        "displayName": "oauth",
         "bintrayPackage": {
             "name": "desirableobjects.grails.plugins:oauth",
             "repo": "grails-plugins",
             "owner": "desirable-objects",
             "desc": "Grails oauth plugin",
             "labels": [
-                
+                "oauth"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1406,21 +1432,21 @@
             "owner": "bertramlabs",
             "desc": "This plugin provides a framework and interface for a synchronization mechanism distributed to multiple server instances.  In today's world of horizontal computational\nscale and massive concurrency, it becomes increasingly difficult to synchronize operations outside the context of a single computational space (server/process).  This plugin aims to make that\neasier by providing a simple service to facilitate this, as well as defining an interface for adding low level providers.\n",
             "labels": [
-                
+                "lock"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/distributed-lock/issues",
-            "latestVersion": "4.0.9",
-            "updated": "2020-11-19T15:24:57.274Z",
+            "latestVersion": "4.0.11",
+            "updated": "2022-10-05T00:17:57.274Z",
             "systemIds": [
                 "com.bertramlabs.plugins:distributed-lock"
             ],
             "vcsUrl": "https://github.com/bertramdev/distributed-lock"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/distributed-lock/maven-metadata.xml",
         "readme": "<h1>Grails Distributed Lock</h1>\n<p>This plugin provides a framework and interface for a synchronization mechanism that can be distributed outside the context of the app container it runs in.  In today's world of horizontal computational\nscale and massive concurrency, it becomes increasingly difficult to synchronize operations outside the context of a single computational space (server/process/container).  This plugin aims to make that\neasier by providing a simple service to facilitate this, as well as defining an interface for adding low level providers.</p>\n<p>In the current release, only a provider for <a href=\"http://redis.io\">redis</a> currently exists, which depends on the <a href=\"http://grails.org/plugin/redis\">grails-redis</a> plugin. Any other providers are welcome contributions.</p>\n<h2>Release Notes</h2>\n<ul>\n<li><strong>0.1:</strong> Initial release</li>\n<li><strong>0.2:</strong> Adding withLock() variations for convenience to LockService impl</li>\n<li><strong>0.2.1:</strong> Minor bug fixes in configuration</li>\n<li><strong>0.2.2:</strong> Minor fix for domain class identification</li>\n</ul>\n<h2>Things to be Done</h2>\n<ul>\n<li>Add Provider for <a href=\"http://memcached.org/\">memcached</a></li>\n<li>Add Provider for <a href=\"http://grails.org/doc/latest/guide/GORM.html\">gorm</a></li>\n<li>Add Provider for <a href=\"http://basho.com/riak\">riak</a></li>\n</ul>\n<h2>Installation</h2>\n<p>Add the plugin to your <strong>BuildConfig.groovy</strong>:</p>\n<pre><code class=\"language-java\">plugins {\n\tcompile &quot;:distributed-lock:0.1.0&quot;\n}\n</code></pre>\n<h2>Configuration</h2>\n<p>First thing is to configure your redis store.  Add sample config to your <strong>Config.groovy</strong>:</p>\n<pre><code class=\"language-java\">grails {\n\tredis {\n\t\thost = 'localhost'\n\t\tport = 6379\n\t}\n}\n</code></pre>\n<p><strong>NOTE:</strong> Please see <a href=\"http://grails.org/plugin/redis\">grails-redis</a> for more configuration details for your redis store</p>\n<p>Next, configure your <strong>distributed-lock</strong> options:</p>\n<pre><code class=\"language-java\">distributedLock {\n\tprovider {\n\t\ttype = RedisLockProvider // Currently the only available provider\n\t\t// NOTE: Use only if not using the default redis connection\n\t\t// connection = 'otherThanDefault'\n\t}\n\traiseError = true //optional\n\tdefaultTimeout = 10000l //optional\n\tdefaultTTL = 1000l * 60l * 60l //optional (1 hour)\n\tnamespace = 'example-app' //optional\n}\n</code></pre>\n<p>Configuration options:</p>\n<ul>\n<li>\n<p><strong>provider:</strong> This block is used to describe your implementation provider</p>\n<ul>\n<li><strong>type:</strong> The implementation class of a low level provider (currently only <strong>RedisLockProvider</strong> avail)</li>\n<li><strong>connection:</strong> Used by redis provider to specify specific connection (if using <a href=\"http://grails.org/plugin/redis\">grails-redis</a> multi connection)</li>\n</ul>\n</li>\n<li>\n<p><strong>raiseError:</strong> Config option to throw exceptions on failures as opposed to just returning boolean status (defaults to 'true')</p>\n</li>\n<li>\n<p><strong>namespace:</strong> Specify a namespace for your lock keys (defaults to 'distributed-lock')</p>\n</li>\n<li>\n<p><strong>defaultTimeout:</strong> The default time (in millis) to wait for a lock acquire before failing (defaults to '30000')</p>\n</li>\n<li>\n<p><strong>defaultTTL:</strong> The TTL (in millis) for an active lock. If its not released in this much time, it will be force released when expired. Value defaults to 0 (never expires)</p>\n</li>\n</ul>\n<h2>Usage</h2>\n<p>The plugin provides a single non transactional service that handles all lock negotiation that you can inject in any of your services</p>\n<pre><code class=\"language-java\">class MyService {\n\tdef lockService\n\t\n\tdef someMethod() {\n\t\tdef lockKey = lockService.acquireLock('/lock/a/shared/fs')\n\t}\n}\n</code></pre>\n<p><strong>LockService Methods</strong></p>\n<ul>\n<li><strong>acquireLock(</strong> <em>String lockName, Map options = null</em> <strong>):</strong> attempts to acquire a lock of <em>lockName</em> with the optional <em>options</em>. Returns true on success.</li>\n<li><strong>acquireLockByDomain(</strong> <em>Object domainInstance, Map options = null</em> <strong>):</strong> Convenience method to acquire a lock derived from a domain class instance. Returns true on success..</li>\n<li><strong>releaseLock(</strong> <em>String lockName, Map options = null</em> <strong>):</strong> release a lock <em>lockName</em> when no longer needed. Returns true on success.</li>\n<li><strong>releaseLockByDomain(</strong> <em>Object domainInstance, Map options = null</em> <strong>):</strong> release a lock derived from a domain class instance. Returns true on success.</li>\n<li><strong>renewLock(</strong> <em>String lockName, Map options = null</em> <strong>):</strong> Can renew the lease on an expiring active lock. If no ttl specified in options, lock ceases to become volatile. Returns true on success.</li>\n<li><strong>renewLockByDomain(</strong> Object domainInstance, Map options = null_ <strong>):</strong> Renew a lock derived from a domain class instance. Returns true on success.</li>\n<li><strong>getLocks()</strong>: Returns a Set&lt;String&gt; of lock names that are currently active in the system.</li>\n</ul>\n<p><strong>Options</strong></p>\n<p>The optional Map allows you to override certain configuration settings just for the context of your method call.  Options include:</p>\n<ul>\n<li><strong>timeout:</strong> time in millis to wait for for the operation to complete before returning failure</li>\n<li><strong>ttl:</strong> time in millis for an acquired lock to expire itself if not released</li>\n<li><strong>raiseError:</strong> boolean instructing whether to throw an exception on failure or just return boolean status</li>\n</ul>\n<h2>Examples</h2>\n<p>Simple usages of <strong>LockService</strong>:</p>\n<pre><code class=\"language-java\">def lockKey = lockService.acquireLock('mylock')\n\t\nif (lockKey) {\n\t// Perform on operation we want synchronized\n}\nelse {\n\tprintln(&quot;Unable to obtain lock&quot;)\n}\n\t\n// try/finally to release lock\ntry {\n\tdef lock = lockService.acquireLock('lock2', [timeout:2000l, ttl:10000l, raiseError:false])\n\tif (lock) {\n\t\t// DO SOME SYNCHRONIZED STUFF\n\t}\n}\nfinally {\n\tlockService.releaseLock('lock2',[lock: lock])\n}\n</code></pre>\n<p>Threaded sample using <a href=\"http://grails.org/plugin/executor\">executor</a> plugin:</p>\n<pre><code class=\"language-java\">def lockService\n\t\n(0..10).each { i -&gt;\n\trunAsync {\n\t\tdef lock\n\t\ttry {\n\t\t\tif (lock = lockService.acquireLock('test-run', [timeout:5000l]))\n\t\t\t\tprintln(&quot;Lock acquired for thread ${i}&quot;)\n\t\t\telse\n\t\t\t\tprintln(&quot;Failed to acquire lock for thread ${i}&quot;)\n\t\t\t\t\n\t\t\t// Sleep for random amount of time\n\t\t\tsleep(new Random().nextInt(1000) as Long)\n\t\t}\n\t\tfinally {\n\t\t\tlockService.releaseLock('test-run',[lock:lock])\n\t\t}\n\t}\n}\n</code></pre>\n<h2>Extending/Contributing</h2>\n<p>To add additional providers is simple.  Simply extend the abstract <strong>com.bertram.lock.LockProvider</strong> class and implement its abstract methods.  Once the new provider is implemented, it must be added to the <strong>LockServiceConfigurer</strong> configuration method.  Please submit contributions via pull request.</p>\n"
     },
     {
@@ -1430,7 +1456,7 @@
             "owner": "budjb",
             "desc": "The Distributed Mutex plugin provides a way to create mutexes backed by a database row. This helps when writing distributed systems that need to lock a resource but database transactions are not sufficient to encapsulate the resource being accessed.",
             "labels": [
-                
+                "lock"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1448,13 +1474,14 @@
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-distributed-mutex\"><img src=\"https://travis-ci.org/budjb/grails-distributed-mutex.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h2>Distributed Mutex Plugin for Grails</h2>\n<p>See the documentation at http://budjb.github.io/grails-distributed-mutex/3.x/latest.</p>\n"
     },
     {
+        "displayName": "grails-simple-captcha",
         "bintrayPackage": {
             "name": "domurtag.plugins:grails-simple-captcha",
             "repo": "plugins",
             "owner": "domurtag",
             "desc": "Grails grails-simple-captcha plugin",
             "labels": [
-                
+                "captcha"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1472,13 +1499,14 @@
         "readme": "<p><a href=\"https://travis-ci.org/donalmurtagh/grails-simple-captcha\"><img src=\"https://travis-ci.org/donalmurtagh/grails-simple-captcha.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>Summary</h2>\n<p>Grails plugin that creates simple image CAPTCHAs that protect against automated completion and submission of HTML forms.</p>\n<h2>Grails Versions</h2>\n<p>Versions of this plugin that are compatible with Grails 1.X and 2.X are on the master branch. Grails 3.X compatible versions are on the grails3 branch. The first Grails 3 compatible version is <code>1.0.0-grails3</code>.</p>\n<h2>Description</h2>\n<h3>Overview</h3>\n<p>A CAPTCHA is a small image that is embedded in a HTML form to protect against automated completion and submission of HTML forms.\nThey generally consist of an image of a short string of random characters visually obsfucated in some way (see <a href=\"http://en.wikipedia.org/wiki/Captcha\">wikipedia</a> for more information).</p>\n<p>This plugin generates a small CAPTCHA image when the CaptchaController is invoked. The CAPTCHA image and it's solution is stored in the session by default,\nthough the pugin can be used without session storage if necessary. A typical example of the CAPTCHAs generated by this plugin is shown below.</p>\n<p><img src=\"grails-app/assets/images/captcha-example.png\" alt=\"Example CAPTCHA\" /></p>\n<h3>Why another CAPTCHA plugin?</h3>\n<p>Although there is already a Grails plugin available for reCAPTCHA (a very popular CAPTCHA implementation), there are a number of differences between these two plugins:</p>\n<ul>\n<li>reCAPTCHA can be slow to load because the CAPTCHA image is created and solved at a remote server. This plugin creates its own CAPTCHA images, so no remote requests are required to create or solve the CAPTCHAs</li>\n<li>reCAPTCHA challenges can be very difficult to solve, whereas the CAPTCHAs generated by this plugin are very easy to solve</li>\n<li>The solution of this plugin's CAPTCHA challenges is case insensitive</li>\n<li>The CAPTCHAs generated by this plugin can be displayed in multiple places on the same page, there is no easy way to do this with reCAPTCHA</li>\n</ul>\n<p>On the other hand, reCAPTCHA provides a number of features that are absent from this plugin, e.g. audio CAPTCHAs for those with impaired vision.</p>\n<h3>Usage</h3>\n<p>A CAPTCHA can be added to a form using the following GSP code</p>\n<pre><code class=\"language-html\">&lt;img src=&quot;${createLink(controller: 'simpleCaptcha', action: 'captcha')}&quot;/&gt;\n&lt;label for=&quot;captcha&quot;&gt;Type the letters above in the box below:&lt;/label&gt;\n&lt;g:textField name=&quot;captcha&quot;/&gt;\n</code></pre>\n<p>As mentioned above, the CAPTCHAs generated by this plugin can be simultaneously displayed in several places on the same page\n(this is only possible with reCAPTCHA if you use JavaScript to clone the CAPTCHA).</p>\n<p>To check whether the solution to the CAPTCHA is correct:</p>\n<pre><code class=\"language-groovy\">class MyController {\n  def simpleCaptchaService\n  // This is the action that handles the submission of the form with the CAPTCHA\n  def save = {\n    boolean captchaValid = simpleCaptchaService.validateCaptcha(params.captcha)   \n  }\n}\n</code></pre>\n<p>The process of validating a CAPTCHA also removes it from the session, so it is only possible to validate each CAPTCHA once.\nThe CAPTCHA is removed from the seesion after validation to ensure that the next time a CAPTCHA is requested, a\ndifferent challenge will be presented.</p>\n<h3>Configuration</h3>\n<p>The plugin provides a number of optional configuration parameters that can be overriden in Config.groovy. The default\nvalues of these parameters are shown below:</p>\n<pre><code class=\"language-groovy\">simpleCaptcha {\n    // font size used in CAPTCHA images\n    fontSize = 30\n    height = 200\n    width = 200\n    // number of characters in CAPTCHA text\n    length = 6\n\n    // amount of space between the bottom of the CAPTCHA text and the bottom of the CAPTCHA image\n    bottomPadding = 16\n\n    // distance between the diagonal lines used to obfuscate the text\n    lineSpacing = 10\n\n    // the charcters shown in the CAPTCHA text must be one of the following\n    chars = &quot;ABCDEFGHIJKLMNOPQRSTUVWXYZ&quot;\n\n    // this param will be passed as the first argument to this java.awt.Font constructor\n    // http://docs.oracle.com/javase/6/docs/api/java/awt/Font.html#Font(java.lang.String,%20int,%20int)\n    font = &quot;Serif&quot;\n}\n</code></pre>\n<h4>Per-Locale Configuration</h4>\n<p>The characters that are shown in the CAPTCHA can be configured per-locale. For example, if you want only the characters\n\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd to be shown by the CAPTCHA in the French locale, add the following to <code>messages_fr.properties</code></p>\n<pre><code>simpleCaptcha.chars=\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\n</code></pre>\n<p>If a locale-specific configuration is found it will override the global configuration in <code>Config.groovy</code></p>\n<h3>Session Storage</h3>\n<p>The plugin stores the CAPTCHA image and its solution in the session by default. If it is not feasible to use session storage,\nthe plugin can instead store a digest (hash) of the solution in a cookie. When a CAPTCHA solution is submitted, it is\nvalidated by comparing the digested solution with this cookie value. This option can be enabled simply by adding the\nfollowing config parameter:</p>\n<pre><code>simpleCaptcha.storeInSession = false\n</code></pre>\n<p>If session storage is disabled it is not possible to display a CAPTCHA in multiple places on the same page.</p>\n"
     },
     {
+        "displayName": "runtime-datasources",
         "bintrayPackage": {
             "name": "domurtag.plugins:runtime-datasources",
             "repo": "plugins",
             "owner": "domurtag",
             "desc": "Grails runtime-datasources plugin",
             "labels": [
-                
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1502,7 +1530,8 @@
             "owner": "grails",
             "desc": "Monitoring And Metrics Plugin For Grails 3",
             "labels": [
-                
+                "metrics",
+                "dropwizard"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1526,7 +1555,9 @@
             "owner": "grails",
             "desc": "Adds Dropwizard metrics reporting to Graphite For Grails 3",
             "labels": [
-                
+                "metrics",
+                "dropwizard",
+                "graphite"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1550,7 +1581,7 @@
             "owner": "dbpatel219",
             "desc": "Change Application Log Levels via Rabbit MQ messages at Runtime.",
             "labels": [
-                
+                "logging"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1571,17 +1602,18 @@
         "bintrayPackage": {
             "name": "elasticsearch",
             "repo": "plugins",
-            "owner": "puneetbehl",
+            "owner": "grails",
             "desc": "Elasticsearch is a search server based on Lucene. It provides a distributed, multitenant-capable full-text search engine with an HTTP web interface and schema-free JSON documents. Elasticsearch is developed in Java and is released as open source under the terms of the Apache License. This is the Grails 3 plugin to support Elasticsearch",
             "labels": [
-                
+                "search",
+                "elasticsearch"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/elasticsearch-grails-plugin/issues",
             "latestVersion": "3.0.0",
-            "updated": "2021-12-26T10:51:16.000Z",
+            "updated": "2022-07-06T10:51:16.000Z",
             "systemIds": [
                 "org.grails.plugins:elasticsearch"
             ],
@@ -1598,14 +1630,16 @@
             "owner": "grails",
             "desc": "Executes an embedded mongo database for integration or functional testing",
             "labels": [
-                
+                "testing",
+                "database",
+                "mongodb"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails-plugins/grails-embedded-mongodb/issues",
             "latestVersion": "2.0.1",
-            "updated": "2021-12-26T08:53:50.000Z",
+            "updated": "2022-10-17T08:53:50.000Z",
             "systemIds": [
                 "org.grails.plugins:embedded-mongodb"
             ],
@@ -1622,7 +1656,9 @@
             "owner": "purpleraven",
             "desc": "Plugin allows to use embedded MySQL in application.",
             "labels": [
-                
+                "testing",
+                "database",
+                "mysql"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1646,7 +1682,9 @@
             "owner": "relaximus",
             "desc": "Plugin allows to use embedded postgres in application.",
             "labels": [
-                
+                "testing",
+                "database",
+                "postgres"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1655,9 +1693,9 @@
             "latestVersion": "1.1.2",
             "updated": "2019-01-17T15:53:30.576Z",
             "systemIds": [
+                "org.grails.plugins:embedded-postgres",
                 "embedded.postgres:embedded-postgres",
-                "embedded.postgres:embedded-postgres-grails-plugin",
-                "org.grails.plugins:embedded-postgres"
+                "embedded.postgres:embedded-postgres-grails-plugin"
             ],
             "vcsUrl": "https://github.com/Relaximus/embedded-postgres-grails-plugin"
         },
@@ -1670,23 +1708,24 @@
             "name": "ember-asset-pipeline",
             "repo": "asset-pipeline",
             "owner": "bertramlabs",
-            "desc": "Compiles hbs or handlebars files for the asset-pipeline into the Ember.TEMPLATES cache",
+            "desc": "Compiles .hbs or .handlebars files for the asset-pipeline into the Ember TEMPLATES cache",
             "labels": [
-                
+                "asset-pipeline",
+                "ember"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/bertramdev/ember-asset-pipeline/issues",
-            "latestVersion": "3.3.1",
-            "updated": "2020-09-24T17:14:13.967Z",
+            "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:13.967Z",
             "systemIds": [
                 "com.bertramlabs.plugins:ember-asset-pipeline"
             ],
-            "vcsUrl": "https://github.com/bertramdev/ember-asset-pipeline"
+            "vcsUrl": "https://github.com/bertramdev/asset-pipeline"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/ember-asset-pipeline/maven-metadata.xml",
         "readme": "<h1>Ember Asset-Pipeline</h1>\n<p><a href=\"https://travis-ci.org/bertramdev/ember-asset-pipeline\"><img src=\"https://travis-ci.org/bertramdev/ember-asset-pipeline.svg\" alt=\"Build Status\" /></a></p>\n<p><strong>MOVED</strong>: This project has moved to a sub project of the main asset-pipeline repository <a href=\"http://github.com/bertramdev/asset-pipeline\">http://github.com/bertramdev/asset-pipeline</a></p>\n<h2>Overview</h2>\n<p>The JVM <code>ember-asset-pipeline</code> is a plugin that provides handlebars template precompiler support  for Ember.js to asset-pipeline.</p>\n<p>Current Ember Version: 1.7.0</p>\n<p>For more information on how to use asset-pipeline, visit <a href=\"http://www.github.com/bertramdev/asset-pipeline\">here</a>.</p>\n<h2>Usage</h2>\n<p>Simply create files in your standard <code>assets/javascripts</code> folder with extension <code>.handlebars</code> or <code>.hbs</code>.\nBy default the templateRoot for your template names is specified as 'templates'. This means that any handlebars file within the root assets/javascripts folder will utilize its file name (without the extension) as its template name. Or a file in <code>templates/show.handlebars</code> would be named <code>templates/show</code>. If templates is set as the templateRoot than it would be named <code>show</code></p>\n<p>It is also possible to change the template path seperator for templatenames to be used by handlebars:</p>\n<p>Gradle Example:</p>\n<pre><code class=\"language-groovy\">assets {\n\tconfig = [\n\thandlebars: [\n\t\ttemplateRoot: 'templates',\n\t\ttemplatePathSeperator: '/'\n\t]\n\t]\n}\n</code></pre>\n<p>Grails Example:</p>\n<pre><code class=\"language-groovy\">grails {\n\tassets {\n\t\thandlebars {\n\t\t\ttemplateRoot = 'templates'\n\t\t\ttemplatePathSeperator = &quot;/&quot;\n\t\t}\n\t}\n}\n</code></pre>\n<p>To use the handlebars runtime simply add handlebars js to your application.js or your gsp file</p>\n<pre><code class=\"language-javascript\">//=require handlebars\n</code></pre>\n<h2>Using in the Browser</h2>\n<p>Template functions are stored in the <code>Handlebars.templates</code> object using the template name. If the template name is\n<code>person/show</code>, then the template function can be accessed from <code>Handlebars.templates['person/show']</code>. See the Template Names section for how template names are calculated.</p>\n<p>See the <a href=\"http://handlebarsjs.com/\">Handlebars.js website</a> for more information on using Handlebars template functions.</p>\n"
     },
     {
@@ -1696,7 +1735,8 @@
             "owner": "grails",
             "desc": "Grails Events - EventBus abstraction for Grails",
             "labels": [
-                
+                "async",
+                "events"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1720,7 +1760,7 @@
             "owner": "exanpe",
             "desc": "Provides easy integration with DataTables.net (Table plug-in for jQuery)",
             "labels": [
-                
+                "datatables.net"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1741,10 +1781,11 @@
         "bintrayPackage": {
             "name": "excel-export",
             "repo": "plugins",
-            "owner": "grails-excel-export",
+            "owner": "touk",
             "desc": "This plugin helps you export data in Excel (xlsx) format, using Apache POI.",
             "labels": [
-                
+                "excel",
+                "export"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1766,10 +1807,11 @@
         "bintrayPackage": {
             "name": "excel-import",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "gpc",
             "desc": "Grails Excel Import Plugin",
             "labels": [
-                
+                "excel",
+                "import"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1790,10 +1832,15 @@
         "bintrayPackage": {
             "name": "export",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "gpc",
             "desc": "Grails export plugin",
             "labels": [
-                
+                "export",
+                "csv",
+                "excel",
+                "ods",
+                "pdf",
+                "xml"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1802,7 +1849,7 @@
             "latestVersion": "2.0.0",
             "updated": "2016-10-03T14:39:59.214Z",
             "systemIds": [
-                
+                "org.grails.plugins:export"
             ],
             "vcsUrl": "https://github.com/gpc/export"
         },
@@ -1817,21 +1864,21 @@
             "owner": "sbglasius",
             "desc": "Load configs with grails.config.locations like in Grails 2.x",
             "labels": [
-                
+                "config"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/sbglasius/external-config/issues",
-            "latestVersion": "3.0.0",
-            "updated": "2022-01-02T10:39:49.954Z",
+            "latestVersion": "3.1.1",
+            "updated": "2022-09-01T14:37:49.000Z",
             "systemIds": [
                 "dk.glasius:external-config"
             ],
             "vcsUrl": "https://github.com/sbglasius/external-config"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/dk/glasius/external-config/maven-metadata.xml",
         "readme": "<p><a href=\"https://github.com/sbglasius/external-config\">See the README</a> on GitHub</p>"
     },
     {
@@ -1841,7 +1888,7 @@
             "owner": "agorapulse",
             "desc": "Grails Facebook SDK plugin",
             "labels": [
-                
+                "facebook"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1865,7 +1912,7 @@
             "owner": "grails",
             "desc": "Grails fields plugin",
             "labels": [
-                
+                "forms"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1883,13 +1930,15 @@
         "readme": null
     },
     {
+        "displayName": "file-viewer",
+        "comment": "There does not seem to exist a published release version compatible with Grails >= 3 as of this writing.",
         "bintrayPackage": {
             "name": "File-Viewer-Grails-Plugin",
             "repo": "plugins",
             "owner": "tothenew",
             "desc": "Grails plugin which allows you to view files stored on the file system.",
             "labels": [
-                
+                "file-viewer"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1898,11 +1947,11 @@
             "latestVersion": null,
             "updated": "2016-03-31T13:31:54.746Z",
             "systemIds": [
-                
+                "org.grails.plugins:file-viewer"
             ],
-            "vcsUrl": "https://github.com/intelligrape/File-Viewer-Grails-Plugin"
+            "vcsUrl": "https://github.com/tothenew/File-Viewer-Grails-Plugin"
         },
-        "documentationUrl": "https://IntelliGrape.github.io/File-Viewer-Grails-Plugin/",
+        "documentationUrl": "https://github.com/tothenew/File-Viewer-Grails-Plugin/wiki",
         "mavenMetadataUrl": null,
         "readme": null
     },
@@ -1923,8 +1972,8 @@
             "latestVersion": "3.0.9",
             "updated": "2018-05-04T00:32:57.027Z",
             "systemIds": [
-                "org.grails.plugins:grails-filterpane",
-                "org.grails.plugins:filterpane"
+                "org.grails.plugins:filterpane",
+                "org.grails.plugins:grails-filterpane"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-filterpane"
         },
@@ -1933,13 +1982,14 @@
         "readme": "<h1>Filterpane Plugin</h1>\n<p>####Build Status####</p>\n<p><a href=\"https://travis-ci.org/Grails-Plugin-Consortium/grails-filterpane\"><img src=\"https://travis-ci.org/Grails-Plugin-Consortium/grails-filterpane.png?branch=master\" alt=\"Build Status\" /></a></p>\n<p>####Documentation Found Here####</p>\n<p><a href=\"http://grails-plugin-consortium.github.io/grails-filterpane/\">Documentation</a></p>\n<p>###Demo Project###</p>\n<p><a href=\"https://github.com/Grails-Plugin-Consortium/grails-filterpane-demo\">Demo</a></p>\n"
     },
     {
+        "displayName": "fixtures",
         "bintrayPackage": {
             "name": "fixtures3",
             "repo": "plugins",
             "owner": "purpleraven",
             "desc": "Load complex domain data via a simple DSL",
             "labels": [
-                
+
             ],
             "licenses": [
                 "Apache-2.0"
@@ -1963,21 +2013,23 @@
             "owner": "bertramlabs",
             "desc": "Creates a simple annotation to mark controller/actions as SSL restricted and performs the appropriate redirect.",
             "labels": [
-                
+                "ssl",
+                "https"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/grails-force-ssl/issues",
-            "latestVersion": "3.1.1",
-            "updated": "2017-11-07T07:34:50.250Z",
+            "latestVersion": "5.0.1",
+            "updated": "2022-02-09T14:50:23.000Z",
             "systemIds": [
+                "com.bertramlabs.plugins:grails-force-ssl",
                 "com.bertramlabs.plugins:force-ssl"
             ],
             "vcsUrl": "https://github.com/bertramdev/grails-force-ssl"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/grails-force-ssl/maven-metadata.xml",
         "readme": "<h1>Grails Force SSL</h1>\n<p>The Grails Force SSL Plugin provides an annotation for controllers to force ssl url endpoints. For example, you may want to restrict a shopping cart page or login page to SSL.</p>\n<h2>Configuration</h2>\n<p>By default, the SSL plugin is enabled for all environments, with the exception of <code>Development</code>. This can be overridden by adjusting your <code>Config.groovy</code></p>\n<pre><code class=\"language-groovy\">grails.plugin.forceSSL.enabled = false\n</code></pre>\n<h3>Grails 3</h3>\n<pre><code class=\"language-yaml\">grails:\n    plugin:\n        forceSSL:\n            enabled: true\n</code></pre>\n<p>The enabled flag can also be defined as a closure which will get passed the request attribute. This allows for evaluation on a per requeset level as to wether or not SSL should be enforced. Can be rather useful for disabling forced SSL for certain URL endpoints (for example server endpoints not behind a load balancer).</p>\n<pre><code class=\"language-groovy\">grails.plugin.forceSSL.enabled = { request -&gt;\n  if(request.serverName == 'app1.bertramlabs.com') {\n    return false\n  }\n  return true\n}\n</code></pre>\n<p>It is also possible to override the https port for the redirect if you want to via:</p>\n<pre><code class=\"language-groovy\">grails.plugin.forceSSL.sslPort = 6443 //optional\n</code></pre>\n<h2>Usage</h2>\n<p>Simply import the SSL annotation and apply at the controller level or at the annotation level.</p>\n<pre><code class=\"language-groovy\">import com.bertramlabs.plugins.SSLRequired\n\n@SSLRequired //Will encrypt entire controller\nclass SessionController {\n  @SSLRequired //Or here for action level\n  def signin() {\n    //Signin Code Here\n  }\n}\n</code></pre>\n<p>Another option is to use a configuration mapping to identify which controllers you wish to be restricted to SSL:</p>\n<pre><code class=\"language-groovy\">  grails {\n    plugin {\n      forceSSL {\n        enabled = true\n        dashboard {\n          index = true\n        }\n        home = true\n      }\n    }       \n  }\n</code></pre>\n"
     },
     {
@@ -1985,16 +2037,17 @@
             "name": "geb",
             "repo": "plugins",
             "owner": "grails",
-            "desc": "Geb Functional Testing for Grails\u00ae framework",
+            "desc": "Geb Functional Testing for Grails framework",
             "labels": [
-                
+                "testing",
+                "geb"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/geb/issues",
             "latestVersion": "3.0.0",
-            "updated": "2021-12-26T05:47:41.000Z",
+            "updated": "2022-06-22T05:47:41.000Z",
             "systemIds": [
                 "org.grails.plugins:geb"
             ],
@@ -2011,31 +2064,33 @@
             "owner": "grails",
             "desc": "GORM GraphQL - Generates a GraphQL schema based on entities in GORM",
             "labels": [
-                
+                "graphql"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/gorm-graphql/issues",
-            "latestVersion": "1.0.2",
-            "updated": "2018-03-08T19:13:29.065Z",
+            "latestVersion": "2.0.0",
+            "updated": "2020-04-06T19:35:05.149Z",
             "systemIds": [
+                "org.grails.plugins:gorm-graphql-plugin",
                 "org.grails.plugins:gorm-graphql"
             ],
             "vcsUrl": "https://github.com/grails/gorm-graphql"
         },
-        "documentationUrl": "https://grails.github.io/gorm-graphql/",
+        "documentationUrl": "https://grails.github.io/gorm-graphql/latest/guide/index.html",
         "mavenMetadataUrl": null,
         "readme": "<h1>Gorm GraphQL</h1>\n<h2>An automatic GraphQL schema generator for GORM</h2>\n<p><a href=\"https://travis-ci.org/grails/gorm-graphql\"><img src=\"https://travis-ci.org/grails/gorm-graphql.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>Current documentation https://grails.github.io/gorm-graphql/latest/guide/index.html</p>\n<h3>Dependencies</h3>\n<ul>\n<li><a href=\"https://github.com/graphql-java/graphql-java\">Graphql Java</a></li>\n</ul>\n"
     },
     {
+        "deprecated": "This entry in the registry is a duplicate of the entry with the name 'gorm-graphql'. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "gorm-graphql-plugin",
             "repo": "plugins",
             "owner": "grails",
             "desc": "GORM GraphQL - Generates a GraphQL schema based on entities in GORM",
             "labels": [
-                
+                "graphql"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2053,13 +2108,15 @@
         "readme": "<h1>Gorm GraphQL</h1>\n<h2>An automatic GraphQL schema generator for GORM</h2>\n<p><a href=\"https://travis-ci.org/grails/gorm-graphql\"><img src=\"https://travis-ci.org/grails/gorm-graphql.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>Current documentation https://grails.github.io/gorm-graphql/latest/guide/index.html</p>\n<h3>Dependencies</h3>\n<ul>\n<li><a href=\"https://github.com/graphql-java/graphql-java\">Graphql Java</a></li>\n</ul>\n"
     },
     {
+        "displayName": "logical-delete",
         "bintrayPackage": {
             "name": "gorm-logical-delete",
             "repo": "plugins",
             "owner": "grails",
             "desc": "Adds logical delete capabilities to GORM",
             "labels": [
-                
+                "database",
+                "logical-delete"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2083,31 +2140,33 @@
             "owner": "9ci",
             "desc": "repository pattern, data services, fast data binding and json/rest/map based query plugin for grails gorm",
             "labels": [
-                
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/yakworks/gorm-tools/issues",
-            "latestVersion": "7.0.8-v.10",
-            "updated": "2021-04-13T17:57:02.143Z",
+            "latestVersion": "7.3.36",
+            "updated": "2022-09-29T22:15:38.000Z",
             "systemIds": [
+                "org.yakworks:gorm-tools",
                 "org.grails.plugins:gorm-tools"
             ],
             "vcsUrl": "https://github.com/yakworks/gorm-tools"
         },
         "documentationUrl": "https://yakworks.github.io/gorm-tools/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/yakworks/gorm-tools/maven-metadata.xml",
         "readme": "<p><a href=\"https://circleci.com/gh/yakworks/gorm-tools\"><img src=\"https://img.shields.io/circleci/project/github/yakworks/gorm-tools/master.svg?longCache=true&amp;style=for-the-badge&amp;logo=circleci\" alt=\"CircleCI\" /></a>\n<a href=\"http://9ci.com\"><img src=\"https://img.shields.io/badge/BUILT%20BY-9ci%20Inc-blue.svg?longCache=true&amp;style=for-the-badge\" alt=\"9ci\" /></a>\n<img src=\"https://forthebadge.com/images/badges/built-with-love.svg\" height=\"28\">\n<img src=\"https://forthebadge.com/images/badges/gluten-free.svg\" height=\"28\">\n<img src=\"https://forthebadge.com/images/badges/made-with-groovy.svg\" height=\"28\"></p>\n<pre style=\"line-height: normal; background-color:#2b2929; color:#76ff00; font-family: monospace; white-space: pre;\">\n\n      ________                                           _.-````'-,_\n     /  _____/  ___________  _____                   ,-'`           `'-.,_\n    /   \\  ___ /  _ \\_  __ \\/     \\          /)     (\\       9ci's       '``-.\n    \\    \\_\\  (  <_> )  | \\/  Y Y  \\        ( ( .,-') )    Yak Works         ```\n     \\______  /\\____/|__|  |__|_|  /         \\ '   (_/                         !!\n            \\/                   \\/           |       /)           '           !!!\n  ___________           .__                   ^\\    ~'            '     !    !!!!\n  \\__    ___/___   ____ |  |   ______           !      _/! , !   !  ! !  !   !!!\n    |    | /  _ \\ /  _ \\|  |  /  ___/            \\Y,   |!!!  !  ! !!  !! !!!!!!!\n    |    |(  <_> |  <_> )  |__\\___ \\               `!!! !!!! !!  )!!!!!!!!!!!!!\n    |____| \\____/ \\____/|____/____  >               !!  ! ! \\( \\(  !!!|/!  |/!\n                                  \\/               /_(      /_(/_(    /_(  /_(   \n         Version: 7.0.8-v.10\n         \n</pre>\n<p><strong>6.1.x is for grails 3.3.x and gorm 6.1.x</strong></p>\n<p><strong>7.0.x is for grails 4.x and gorm 7.0.x</strong></p>\n<blockquote>\n<p><em>DOCS ARE OUT OF DATE AND BEING UPDATED FOR BREAKING CHANGES IN 6.1.12-v.X</em>\n<em>ALSO MERGING IN DOCS FOR THE REST-API AND AUDITSTAMP THAT WAS MERGED INTO HERE</em>\nMore breaking changes in 7.0.8-v6. is required on domain entity now or it needs to implement @GormRepoEntity</p>\n</blockquote>\n<p><a href=\"docs/release-notes.md\">RELEASE NOTES</a></p>\n<p>| Guide | API |\n|------|--------|\n|<a href=\"https://yakworks.github.io/gorm-tools/\">Released Docs</a> | <a href=\"https://yakworks.github.io/gorm-tools/api\">Released Api</a>\n|<a href=\"https://yakworks.github.io/gorm-tools/snapshot\">snapshot</a> | <a href=\"https://yakworks.github.io/gorm-tools/snapshot/api\">snapshot</a></p>\n<pre><code>compile &quot;org.grails.plugins:gorm-tools:6.1.12-v.2&quot;\n</code></pre>\n<p>Gorm-tools allows your Grails/Gorm project to start with a design of best practices that they can customize along the way.\nThis brings an opinionated starting point to a Grails/Gorm project but without being locked in.\nDevelopers are free to easily customize, replace and disable these patterns when their opinions differ.</p>\n<h2>Overview</h2>\n<p>This is a library of tools to help standardize and simplify the service and Restful controller layer business logic for\ndomains and is the basis for the <a href=\"https://yakworks.github.io/gorm-rest-api/\">Gorm Rest API plugin</a>{.new-tab}.</p>\n<p>Gorm-Tools is the next iteration on the <a href=\"https://grails.org/plugin/dao\">DAO plugin</a> and has been in use for about 10 years processing millions of transactions per day.</p>\n<p>There are 3 primary patterns this library enables as detailed below for Repositories,\nMango ( A mongo/graphql like query way to get gorm entity data with a Map) and\nBatch or Bulk inserting and updating with data binding</p>\n<h2>Domain Repository Services</h2>\n<p><small><a href=\"docs/repository/ref.md\">jump to reference</a></small></p>\n<p>A repository is a <a href=\"docs/usefulLinks.md#references\">Domain Driven Design</a> pattern. Used a a place logic to validate, bind, persist and query data that resides\neither in a database or NoSql (via GORM usually of course).\nThe design pattern here is a bit similiar to <a href=\"https://docs.spring.io/spring-data/data-commons/docs/current/reference/html/\">Spring's Repository pattern</a>\nand Grails GORM's new <a href=\"http://gorm.grails.org/6.1.x/hibernate/manual/#dataServices\">Data Services</a> pattern.</p>\n<h3>Goals</h3>\n<ul>\n<li><strong>Standardization</strong>: a clean common pattern across our apps for domain service layer logic that\nreduces boiler plate in both services as well as controllers.</li>\n<li><strong>Transactional Saves</strong>: every save() or persist() is wrapped in a transaction if one doesn't already exist.\nThis is critical when there are cascading saves and updates.</li>\n<li><strong>RuntimeException Rollback by default</strong>: saves or <code>persist()</code> always occur with failOnError:true so a RuntimeException is\nthrown for both DataAccessExceptions as well a validation exceptions.\nThis is critical for deeply nested domain logic dealing with saving multiple domains chains.</li>\n<li><strong>Events &amp; Validation</strong>: the Repository allows a central place to do events such as beforeSave, beforeValidate, etc\nso as not to pollute the domain class. This pattern makes it easier to keeps the special logic in a transaction as well.\nAllows validation outside of constraints to persistence without needing to modify the domain source.</li>\n<li><strong>Events with Flushing</strong>: As mentioned in the Gorm docs, &quot;Do not attempt to flush the session within an event\n(such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.&quot;.\nPutting the event business logic in the Repository keeps it all in a normal transaction and a flush is perfectly fine.</li>\n<li><strong>Easy Override/Replace Plugin's Domain Logic</strong>: Since the Repository is a service this also easily allows default logic in a provided\nplugin to be overriden in an application. For example, I may have a CustomerRepo in a plugin that deals with deault common\nlogic to validate address. I can then implement a CustomerRepo in an application and it will override the spring bean\njust as it does for a service.</li>\n</ul>\n<h2>Fast Data Binder &amp; Batch Insert/Update</h2>\n<p>We process millions of transactions per day and needed more performant binding performance.</p>\n<h3>Goals</h3>\n<ul>\n<li><strong>FAST Data Binding Service</strong>: databinding from maps (and thus JSON) has to be fast.\nWe sacrfice a small amount of functionality for a big performance gain\nMaps and json are a first class citizen in the data service layer instead of the controller layer.\nEliminates boiler plate in getting data from the database to Gorm to JSON Map then back again.</li>\n<li><strong>Asynchronous batch processing PERFORMANCE</strong>: GORM insert and updates can be chunked and processed in parrallel\nusing GPARS or RxJava making it easy to processes millions of records from JSON, CSV or Excel</li>\n</ul>\n<h2>JSON Query and Filtering (Mango Query)</h2>\n<p>The primary motive here is to create an easy dynamic map based way to query any Gorm Datastore (SQL or NoSQL).\nUsing a simple map that can come from json, yaml, groovy config etc...\nA huge motivating factor being able is to be able to have a powerful and flexible way to query using json from a REST\nbased client without having to use <em>GraphQL</em> (the only other clean alternative)\nThe Repositories and RestApiController come with a <code>query(criteriaMap, closure)</code> method. It allows you to get a paginated\nlist of entities restricted by the properties in the <code>criteriaMap</code>.</p>\n<ul>\n<li>A lot of inspiration was drawn from <a href=\"https://restdb.io/docs/querying-with-the-api\">Restdb.io</a></li>\n<li>the query language is similar to <a href=\"https://docs.mongodb.com/manual/reference/operator/query/\">Mongo's</a></li>\n<li>and CouchDB's new <a href=\"http://docs.couchdb.org/en/latest/api/database/find.html#selector-syntax\">Mango selector-syntax</a> .</li>\n<li>Also inspired by <a href=\"https://github.com/2do2go/json-sql/\">json-sql</a></li>\n</ul>\n<blockquote>\n<p>:memo:\nWhilst selectors have many similarities with MongoDB query documents,\nthese arise more from a similarity of purpose and do not necessarily extend to commonality of function or result.</p>\n</blockquote>\n<p><strong>Example</strong>\nfor example, sending a JSON search param that looks like this</p>\n<pre><code class=\"language-js\">{\n  &quot;name&quot;: &quot;Bill%&quot;,\n  &quot;type&quot;: &quot;New&quot;,\n  &quot;age&quot;: {&quot;$gt&quot;: 65}\n}\n</code></pre>\n<p>would get converted to the equivalent criteria</p>\n<pre><code class=\"language-javascript\">criteria.list {\n    ilike &quot;name&quot;, &quot;Bill%&quot;\n    eq &quot;type&quot;, &quot;New&quot;\n    gt &quot;age&quot;, 65\n}\n</code></pre>\n<h2>Developer Notes</h2>\n<h3>Running docs locally</h3>\n<p>Docs are built with https://yakworks.github.io/docmark/\nRun  <code>./build.sh dockmark-serve</code> or <code>make dockmark-serve</code></p>\n<h3>Publishing Plugin Releases</h3>\n<p>See <a href=\"docs/developer.md\">Developer Docs</a> for info on our release process</p>\n<p><strong>Using latests SNAPSHOT</strong></p>\n<p>Configure 9ci repo in build.gradle</p>\n<pre><code class=\"language-groovy\">repositories {\n  maven { url &quot;http://repo.9ci.com/oss-snapshots&quot; }\n }\n</code></pre>\n<p>See <a href=\"version.properties\">version.properties</a> for snapshot version</p>\n<pre><code class=\"language-groovy\">dependencies {\n compile('org.grails.plugins:gorm-tools:x.y.z-SNAPSHOT') { changing = true } \n}\n</code></pre>\n"
     },
     {
+        "displayName": "advanced-config",
         "bintrayPackage": {
             "name": "grails-advanced-config",
             "repo": "plugins",
             "owner": "reid",
             "desc": "Grails Advanced Config Plugin",
             "labels": [
-                
+                "config"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2125,13 +2184,14 @@
         "readme": "<h1>Grail Advanced Config Plugin</h1>\n<p>A small Gradle plugin built to help with Grails config files.</p>\n<p>It takes config files from different locations and composes it into <strong>application.yml</strong></p>\n<p><img src=\"https://github.com/RealizeIdeas/grails-advanced-config/blob/master/src/docs/img/config_structure.png\" alt=\"Config structure\" /></p>\n<h2>Setup</h2>\n<p>Basic setup in <strong>build.gradle</strong>:</p>\n<pre><code class=\"language-groovy\">buildscript {\n    repositories {\n        maven { url &quot;https://dl.bintray.com/reid/plugins&quot; }\n    }\n    dependencies {\n        classpath 'net.realizeideas:grails-advanced-config:1.0'\n    }\n}\napply plugin: &quot;net.realizeideas.grails-advanced-config&quot;\n</code></pre>\n<p>By default plugin takes all input config files from:</p>\n<ul>\n<li>grails-app/conf/configurations/common</li>\n<li>grails-app/conf/configurations/&quot;${grails.env}&quot;</li>\n</ul>\n<p>You can override this behavior and set required config files manually:</p>\n<pre><code class=\"language-groovy\">advancedConfig {\n   configFiles = files(\n        'grails-app/conf/config1.yml',\n        'grails-app/conf/config2.yml',\n   ) as List\n}\n</code></pre>\n<h2>Supported file format</h2>\n<p>For input files:</p>\n<ul>\n<li>yml</li>\n<li>groovy</li>\n<li>json</li>\n<li>xml</li>\n</ul>\n<p>Output file - <strong>application.yml</strong></p>\n"
     },
     {
+        "displayName": "appinfo",
         "bintrayPackage": {
             "name": "grails-appinfo",
             "repo": "plugins",
             "owner": "ikalizpet",
             "desc": "A Grails plugin to provide applicaiton system information for health-check and runtime inspection",
             "labels": [
-                
+                "health-check"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2149,13 +2209,14 @@
         "readme": "<h1>grails-appinfo</h1>\n<p>Grails plugin to check and monitor application status with a dashboard UI</p>\n<p><a href=\"https://travis-ci.org/binlecode/grails-appinfo\"><img src=\"https://travis-ci.org/binlecode/grails-appinfo.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>INTRODUCTION</h2>\n<p>Grails-appinfo Grails plugin is a set of convenient utilities for application\nsystem details, health-check, configuration and monitoring at runtime.</p>\n<p>This Grails plugin builds on top of spring boot actuator API with Grails specific\nenhancements on stock actuator endpoints.</p>\n<p>To consume actuator JSON endpoints, the testing Grails application also provides a monitoring\ndashboard inspired by <a href=\"https://github.com/dmahapatro/grails-actuator-ui\">grails-actuator-ui</a>.</p>\n<p>The dashboard UI is built on bootstrap with CSS framework from <a href=\"https://adminlte.io/\">AdminLTE</a>.</p>\n<p>This repository contains source code of Grails-appinfo plugin, and a testing host Grails application.</p>\n<h2>INSTALL</h2>\n<p>In host Grails application's build.gradle file:</p>\n<pre><code class=\"language-groovy\">plugins {\n    compile ':grails-appinfo:$version'\n}\n</code></pre>\n<h2>PREREQUISITES</h2>\n<p>Hosting Grails application version 3.0+.</p>\n<h2>CONFIGURATION</h2>\n<p>In host Grails application grails-app/conf/application.yml</p>\n<pre><code class=\"language-yaml\"># Appinfo grails plugin settings\nappinfo:\n    health:\n        mongodb:\n            # hide or show password in the mongodb connection url if it contains credential info\n            # if set to false (default if not set), the password will be replaced as '&lt;pswd&gt;'\n            showPassword: false  # default to false\n        urls:   # list of webservice endpoints to check\n            - url: 'http://localhost:8080'\n              name: 'web root'   # name of the endpoint\n              method: 'GET'      # http method, default to 'HEAD' if not given\n            - url: 'http://localhost:8080/info'\n              name: 'web_info'\n        aws:\n            s3:\n                # either:\n                bucket: 'bucket-name'  # bucket name used in s3 health check\n                # or: (for multiple buckets)\n                #buckets:\n                #    - 'bucket-name'\n                #    - 'another-bucket-name'\n    info:\n        # add 'grails-system-info' to Actuator info endpoint, default (if not set) is not enabled\n        system: true\n        # add 'grails-logging-info' to Actuator info endpoint, default (if not set) is not enabled\n        logging: true\n        # add following keys to Actuator info endpoint, default (if not set) is not enabled\n        # - 'jvm-version'\n        # - 'groovy-version'\n        # - 'grails-runtime-environment'\n        # - 'grails-reload-enabled'\n        # - 'grails-runtime-threads-info'\n        runtime: true\n</code></pre>\n<h2>SAMPLE APPLICATION</h2>\n<p>The plugin provides RESTful json view by itself with endpoints as below:\n<code>&lt;root-context&gt;/</code> followed by <code>autoconfig</code>, <code>configprops</code>, <code>dump</code>, <code>env</code>, <code>health</code>, <code>info</code>, <code>metrics</code>, <code>mappings</code>, <code>shutdown</code>, <code>trace</code>, <code>beans</code>.</p>\n<p>Most of them are decorators of Spring Boot Actuator native endpoints. But with enhanced information and connectivity support such as mongodb, s3, generic web url endpoint, etc.</p>\n<p>For example, <code>localhost:8080/health</code> endpoint returns:</p>\n<pre><code class=\"language-json\">{\n    &quot;status&quot;: &quot;DOWN&quot;,\n    &quot;diskSpace&quot;: {\n        &quot;status&quot;: &quot;UP&quot;,\n        &quot;total&quot;: 499963170816,\n        &quot;free&quot;: 281595985920,\n        &quot;threshold&quot;: 262144000\n    },\n    &quot;urlHealthCheck_web_info&quot;: {\n        &quot;status&quot;: &quot;UP&quot;,\n        &quot;url&quot;: &quot;http://localhost:8080/info&quot;,\n        &quot;method&quot;: &quot;HEAD&quot;,\n        &quot;timeout.threshold&quot;: &quot;10000 ms&quot;\n    },\n    &quot;databaseHealthCheck&quot;: {\n        &quot;status&quot;: &quot;UP&quot;,\n        &quot;database&quot;: &quot;H2&quot;,\n        &quot;hello&quot;: 1\n    },\n    &quot;urlHealthCheck_webroot&quot;: {\n        &quot;status&quot;: &quot;UP&quot;,\n        &quot;url&quot;: &quot;http://localhost:8080&quot;,\n        &quot;method&quot;: &quot;GET&quot;,\n        &quot;timeout.threshold&quot;: &quot;10000 ms&quot;\n    },\n    &quot;mongodbHealthCheck&quot;: {\n        &quot;status&quot;: &quot;DOWN&quot;,\n        &quot;url&quot;: &quot;mongodb://localhost/test_grails_appinfo&quot;,\n        &quot;db&quot;: &quot;test_grails_appinfo&quot;,\n        &quot;error&quot;: &quot;java.lang.Exception: MongoDB check timed out after 3000 ms&quot;\n    },\n    &quot;s3HealthCheck&quot;: {\n        &quot;status&quot;: &quot;DOWN&quot;,\n        &quot;endpoint&quot;: &quot;https://s3.amazonaws.com&quot;,\n        &quot;error&quot;: &quot;java.lang.Exception: S3 check fail: Unable to load AWS credentials from any provider in the chain&quot;\n    }\n}\n</code></pre>\n<p>The sample application also includes a Bootstrap styled dashboard with url:\n<code>&lt;root-context&gt;/appinfoDashboard</code> which renders information with ajax call to above endpoints.</p>\n<p>The web UI components are straightforward:</p>\n<ul>\n<li>gsp in folder <code>views/appinfoDashboard</code></li>\n<li>layout template <code>views/layouts/appinfo.gsp</code></li>\n<li>taglib <code>taglib/grails/plugin/appinfo/AvatarTaglib.groovy</code></li>\n</ul>\n<p>UI static resource files are:</p>\n<ul>\n<li><code>grails-app/assets/images/appinfo</code></li>\n<li><code>grails-app/assets/javascripts/appinfo</code></li>\n<li><code>grails-app/assets/stylesheets/appinfo</code></li>\n</ul>\n<p>Here are some screenshots of v1.3 sample application UI:</p>\n<ul>\n<li>dashboard\n<img src=\"screenshots/appinfo-ui-dashboard.png?raw=true\" alt=\"Alt appinfo UI dashboard\" title=\"appinfo-ui dashboard\" /></li>\n<li>URL mappings\n<img src=\"screenshots/appinfo-ui-mappings.png?raw=true\" alt=\"Alt appinfo UI URL mappings\" title=\"appinfo-ui url mappings trace\" /></li>\n<li>http call trace\n<img src=\"screenshots/appinfo-ui-trace.png?raw=true\" alt=\"Alt appinfo UI http trace\" title=\"appinfo-ui http trace\" /></li>\n<li>runtime beans\n<img src=\"screenshots/appinfo-ui-beans.png?raw=true\" alt=\"Alt appinfo UI beans\" title=\"appinfo-ui beans\" /></li>\n</ul>\n<h2>CHANGELOG</h2>\n<h4>1.3.1</h4>\n<ul>\n<li>fix: sample app boot-up fails when aws-s3 setting is commented out in app yaml</li>\n<li>document enhancement with sample app UI dashboard config and screenshot</li>\n</ul>\n<h4>1.3</h4>\n<ul>\n<li>support both AWS SDK Grails plugin version 1.x and 2.x.</li>\n</ul>\n<h4>1.2</h4>\n<ul>\n<li>fix mongodb check timeout error during healthcheck</li>\n<li>enhancements of loggingInfo exposure in Actuator endpoint</li>\n<li>restore runtime logger management web UI because of SpringBoot Actuator v1.4's lack of loggers RESTful endpoint</li>\n</ul>\n<h4>v1.1</h4>\n<ul>\n<li>add password shadowing option for mongodb connection url</li>\n</ul>\n<h4>v1.0</h4>\n<ul>\n<li>stable release for Grails 3.2.x, with Spring Boot 1.4 and GORM 6.0</li>\n</ul>\n<h4>v0.9</h4>\n<ul>\n<li>support both multi-dataSources and single dataSource in health check</li>\n<li>support mongodb in health check</li>\n</ul>\n<h2>CONTRIBUTORS</h2>\n<p>Bin Le (bin.le.code@gmail.com)</p>\n<h2>LICENSE</h2>\n<p>Apache License Version 2.0. (http://www.apache.org/licenses/)</p>\n"
     },
     {
+        "displayName": "bootstrap-forms",
         "bintrayPackage": {
             "name": "grails-bootstrap-forms",
             "repo": "plugins",
             "owner": "jvilaplana",
             "desc": "Easy form fields generation taglib.",
             "labels": [
-                
+                "bootstrap"
             ],
             "licenses": [
                 "MIT"
@@ -2173,13 +2234,15 @@
         "readme": "<h1>Grails Bootstrap Forms</h1>\n<p>A Grails 3 plugin to automatically generate form fields using Bootstrap 4.</p>\n<h2>Overview</h2>\n<p>The grails-bootstrap-forms plugin offers an easy-to-use TagLib to render fields in views.</p>\n<h2>Basic usage</h2>\n<p>Add the Bintray repository to your <code>build.gradle</code> file:</p>\n<pre><code>buildscript {\n    repositories {\n        ...\n        maven { url &quot;http://dl.bintray.com/jvilaplana/plugins&quot; }\n    }\n}\n</code></pre>\n<p>Add the dependency to your project's <code>build.gradle</code> file:</p>\n<pre><code>dependencies {\n    ...\n    compile 'grails.bootstrap.forms:grails-bootstrap-forms:0.3.3'\n}\n</code></pre>\n<p>Add the stylesheet to your project's <code>application.css</code> file:</p>\n<pre><code>*= require bootstrap-forms\n</code></pre>\n<p>There is a tag to display a field for <code>show.gsp</code> views and another one to render form fields.</p>\n<p>To show a field you can use:</p>\n<p><code>&lt;bf:showField bean=&quot;${user}&quot; property=&quot;username&quot; /&gt;</code></p>\n<p>To render a form field you can use:</p>\n<p><code>&lt;bf:formField bean=&quot;${user}&quot; property=&quot;username&quot; /&gt;</code></p>\n<h3>Documentation</h3>\n<h4>showField attributes</h4>\n<p>| Attribute | Description |\n| --------- | ----------- |\n| <code>bean</code> | Instance |\n| <code>property</code> | Property of the <code>bean</code> to be rendered |\n| <code>width</code> | <a href=\"http://getbootstrap.com/docs/4.1/layout/grid/\">Column width</a>, defaults to <code>3</code> |\n| <code>type</code> | Type of the property to be rendered. One of <code>text</code>, <code>textarea</code>, <code>number</code>, <code>date</code>, <code>time</code>, <code>datetime</code> or <code>select</code>. If not specified, the type will be guessed.\n| <code>addon</code> | If specified, its value will be appended to the field. |\n| <code>cssClass</code> | A CSS class that will be added to the field |</p>\n<h4>formField attributes</h4>\n<p>| Attribute | Description |\n| --------- | ----------- |\n| <code>bean</code> | Instance |\n| <code>property</code> | Property of the <code>bean</code> to be rendered |\n| <code>width</code> | <a href=\"http://getbootstrap.com/docs/4.1/layout/grid/\">Column width</a>, defaults to <code>3</code> |\n| <code>type</code> | Type of the property to be rendered. One of <code>text</code>, <code>textarea</code>, <code>number</code>, <code>date</code>, <code>time</code>, <code>transient</code> or <code>select</code>. If not specified, the type will be guessed.\n| <code>addon</code> | If specified, its value will be appended to the field. |\n| <code>cssClass</code> | A CSS class that will be added to the field |\n| <code>required</code> | Set its value to <code>required</code> to set the field as required. |\n| <code>height</code> | Set the <a href=\"http://getbootstrap.com/docs/4.1/components/forms/#sizing\">sizing of the field</a> to <code>lg</code> or <code>sm</code>.\n| <code>rows</code> | Set the number of rows for fields with <code>type=&quot;textarea&quot;</code>.\n| <code>name</code> | Set the <code>name</code> and <code>id</code> attributes of the field. Defaults to <code>property</code>. |</p>\n<p><a href=\"https://bintray.com/jvilaplana/plugins/grails-bootstrap-forms/_latestVersion\"><img src=\"https://api.bintray.com/packages/jvilaplana/plugins/grails-bootstrap-forms/images/download.svg\" alt=\"Download\" /></a></p>\n"
     },
     {
+        "displayName": "executor",
+        "deprecated":  "Source repository is archived. As per the readme: This plugin is not maintained - use grails-async. This entry in the registry should probably be removed.",
         "bintrayPackage": {
             "name": "grails-executor",
             "repo": "plugins",
             "owner": "uberall",
             "desc": "Full plugin description",
             "labels": [
-                
+                "async"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2198,12 +2261,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-google-visualization",
+            "name": "google-visualization",
             "repo": "plugins",
-            "owner": "aruizca",
+            "owner": "bmuschko",
             "desc": "Grails grails-google-visualization plugin",
             "labels": [
-                
+                "google"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2222,12 +2285,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-gscripting",
+            "name": "gscripting",
             "repo": "maven",
             "owner": "frnktrgr",
             "desc": "Run Groovy scripts in Grails",
             "labels": [
-                
+                "scripting"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2245,13 +2308,14 @@
         "readme": "<h1>grails-gscripting</h1>\n<p>Run Groovy scripts in Grails</p>\n<p>##Logging (Config.groovy):</p>\n<pre><code>debug 'grails.plugin.gscripting',\n      'grails.app.services.grails.plugin.gscripting'\n</code></pre>\n<p>##Create a script and run it</p>\n<pre><code class=\"language-groovy\">def gscriptingService\ndef sre = gscriptingService.createScriptRuntimeEnv(&quot;Foo&quot;, '''\nprocess([c:&quot;hello&quot;, d:&quot;world&quot;]) {\n  // call another service\n\t// app.fooService.bar();\n\tlog.info(&quot;callParams: &quot;+ctx.callParams);\n\tlog.info(&quot;scriptParams: &quot;+scriptParams);\n\tlog.debug(&quot;metadata: &quot;+ctx.metadata);  3 + 4 + 2\n}\n''')\nsre.run([a:23, b:42])\nsre.run()\n</code></pre>\n<p><code>gscriptingService.createScriptRuntimeEnv(String label, String sourcecode)</code> creates a new script with the default DSL provider. In the closure given as an argument to <code>process(Map scriptParams) { &lt;HERE&gt; }</code> you can use some DSL properties as described below:</p>\n<ul>\n<li><code>log</code>: logger</li>\n<li><code>scriptParams</code>: the map given as first argument to <code>process</code></li>\n<li><code>grailsApplication</code>: grailsApplication instance like in controllers or services</li>\n<li><code>app.&lt;serviceName&gt;</code>: services of your Grails application, e.g. gscriptingService</li>\n<li><code>ctx</code>: the default context as described below:\n<ul>\n<li><code>ctx.callParams</code>: the map given as an argument to <code>run</code></li>\n<li><code>ctx.metadata</code>: a map with <code>qualifiedName</code>, <code>sourcecode</code>, and <code>instanceIndex</code> (see below)</li>\n<li><code>ctx.state</code>: a map for variables, can also be access directly, e.g. <code>ctx.state.foo = 42</code> is the same as <code>foo = 42</code></li>\n<li><code>ctx.shared</code>: a map shared by every instance of the script (not synchronized)\nYou can run a script multiple times, once you created it. Simple call <code>run()</code> or <code>run(Map callParams)</code> on the script. <code>stats()</code> returns simple statistics like min/max/average execution time.</li>\n</ul>\n</li>\n</ul>\n<p>##Register script and run by qualified name</p>\n<pre><code class=\"language-groovy\">def gscriptingService\ngscriptingService.registerScriptRuntimeEnv(&quot;foo.Bar&quot;, '''\nprocess([first:&quot;hello&quot;, second:&quot;world&quot;]) {\n\t// call another service\n\t// app.fooService.bar();\n\tlog.info(&quot;callParams: &quot;+ctx.callParams);\n\tlog.info(&quot;scriptParams: &quot;+scriptParams);\n\tlog.debug(&quot;metadata: &quot;+ctx.metadata);  3 + 4 + 2\n}\n''')\ngscriptingService.run(&quot;foo.Bar&quot;)\ngscriptingService.run(&quot;foo.Bar&quot;, [a:23, b:42])\n</code></pre>\n<p>In order to provide a script to your whole application, you can register a script under a qualified name. Register an updated script again with the same qualified name in order to reload it.</p>\n<p>##Multi-threading and thread-safety\nRunning scripts is thread-safe. If a script is still running and you invoke run again, e.g. in another thread, a new instance will be created and started. The actual instance index can be accessed via the context (see above <code>instanceIndex</code>).</p>\n"
     },
     {
+        "deprecated": "Source repository is archived. This entry should probably be removed from the registry.",
         "bintrayPackage": {
-            "name": "grails-hibernate-filter",
+            "name": "hibernate-filter",
             "repo": "grails-plugins",
             "owner": "piotrchowaniec",
             "desc": "",
             "labels": [
-                
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2270,12 +2334,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-hibernate-filter",
+            "comment": "Does not work with Grails > 3.2.* as of v0.5.5 (according to https://github.com/alexkramer/grails-hibernate-filter/issues/13)",
+            "name": "hibernate-filter",
             "repo": "grails3-plugins",
             "owner": "goodstartgenetics",
             "desc": "Provides utilities to define hibernate filters on classes and collections. Meant to be used with Grails 3.2 and higher, Hibernate 5, and GORM 6",
             "labels": [
-                
+                "database"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2294,21 +2359,20 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-isomorphic",
+            "name": "isomorphic",
             "repo": "plugins",
             "owner": "zacharyklein",
             "desc": "Grails Isomorphic Rendering Plugin",
             "labels": [
-                "grails",
                 "isomorphic",
+                "ssr",
                 "javascript",
-                "plugin",
                 "react"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "",
+            "issueTrackerUrl": "https://github.com/ZacharyKlein/grails-isomorphic/issues",
             "latestVersion": "1.2",
             "updated": "2016-12-02T17:18:40.820Z",
             "systemIds": [
@@ -2322,12 +2386,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-java8",
+            "name": "java8",
             "repo": "plugins",
             "owner": "grails",
             "desc": "Provides support for Java 8 specific features in Grails",
             "labels": [
-                
+                "java-date-time"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2346,12 +2410,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-json-apis",
+            "comment": "This plugin has been updated to Grails 4 but there is no release yet that works with Grails > 3",
+            "name": "json-apis",
             "repo": "plugins",
             "owner": "gregopet",
             "desc": "",
             "labels": [
-                
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2370,12 +2435,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-mailgun",
+            "name": "mailgun",
             "repo": "grails-plugin",
             "owner": "orkonano",
             "desc": "Grails grails-mailgun plugin",
             "labels": [
-                
+                "mail",
+                "mailgun"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2394,12 +2460,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-mailwatcher",
+            "name": "mailwatcher",
             "repo": "plugins",
             "owner": "junehasissues",
             "desc": "This Plugin reads unread mails from provided mail account Id. To Grails 3 updated Version of https://github.com/IntelliGrape/Grails-Mail-Watcher-Plugin.",
             "labels": [
-                
+                "mail"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2418,12 +2484,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-melody-plugin",
+            "name": "melody",
             "repo": "plugins",
             "owner": "sergiomichels",
             "desc": "Integrate JavaMelody monitoring into Grails application.",
             "labels": [
-                
+                "javamelody"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2442,12 +2508,14 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-memcached-web-plugin",
+            "comment": "Only Grails 3.2, 3.3 supported as of 1.2",
+            "name": "memcached-web-plugin",
             "repo": "plugins",
             "owner": "purpleraven",
             "desc": "Store pages of page fragments in memcached",
             "labels": [
-                
+                "cache",
+                "memcached"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2465,37 +2533,40 @@
         "readme": "<h1>grails-cows-cache-plugin</h1>\n<p><a href=\"https://bintray.com/purpleraven/plugins/grails-memcached-web-plugin/_latestVersion\"><img src=\"https://api.bintray.com/packages/purpleraven/plugins/grails-memcached-web-plugin/images/download.svg\" alt=\"Download\" /></a></p>\n<p>The plugin provides possibility to store pages of page fragments in <a href=\"https://www.memcached.org/\">memcached</a> and use it directly from web servers</p>\n<p>thx. to ehcache web for web filter code</p>\n<p>Grails 3.2, 3.3 supported</p>\n<h2>Usage</h2>\n<p>Base logic:</p>\n<ul>\n<li>on first page access, nginx request memcached and receives empty result.</li>\n<li>as a fallback, nginx request web application.</li>\n<li>if action marked as memcached, page will be rendered and added to memcached</li>\n<li>response from web application will be returned to user</li>\n<li>on next requests, content from memcached will be used without calling web application</li>\n<li>dynamic parts of page can be requested by SSI <a href=\"https://en.wikipedia.org/wiki/Server_Side_Includes\">doc</a> on server side or by ajax from client</li>\n</ul>\n<p>Plugin can be disabled by <code>memcached.disabled=true</code> setting</p>\n<p>Controllers actions can be marked by <code>@Memcached(value = 7200, packed = true)</code> annotation or by MemcachedHelper.mark(request, 7200)</p>\n<p>cached content can be removed by <code>memcachedService.remove(url)</code> or <code>memcachedService.flush()</code></p>\n<p>SSI for dynamic content supported , see <a href=\"https://en.wikipedia.org/wiki/Server_Side_Includes\">doc</a></p>\n<pre><code class=\"language-html\">&lt;!--# include virtual=&quot;${createLink(controller: 'controller', action: 'action', id:id)}&quot; wait='yes'--&gt;\n</code></pre>\n<p>or</p>\n<pre><code class=\"language-html\">&lt;mc:memcachedTile url=&quot;${createLink(controller:'controller',action:'action', id:id))}&quot;&gt;\n   &lt;span&gt;Content for non-cached page&lt;/span&gt;\n&lt;/mc:memcachedTile&gt;\n</code></pre>\n<p><code>&lt;mc:memcachedLog/&gt;</code> shows caching time if memcached activated fror the page</p>\n<h2>Installation</h2>\n<p>Add the following dependencies in <code>build.gradle</code></p>\n<pre><code>repositories {\n...\n  maven { url &quot;http://dl.bintray.com/purpleraven/plugins&quot; }\n...\n}\ndependencies {\n...\n    compile 'org.grails.plugins:grails-memcached-web-plugin:1.2'\n...\n}\n</code></pre>\n<p>In web application config, example for Nginx</p>\n<pre><code>\n  upstream app.port {\n    server localhost:8080; # tomcat port\n  }\n  \n  upstream memcached.port {\n    server localhost:11211; # memcached port\n  }\n  \n  # without compression, bug ssi supported\n  location / {\n      ssi on; \n      set $memcached_key &quot;$uri?$args&quot;;\n      memcached_pass memcached.port;\n      memcached_gzip_flag 2;\n      default_type text/html;\n      charset utf-8;\n      gunzip on;\n      proxy_set_header Accept-Encoding &quot;gzip&quot;;\n      error_page  404 405 400 500 502 503 504 = @fallback;\n    }\n  \n  location @fallback {\n      ssi on;\n      proxy_pass http://app.port;\n      proxy_max_temp_file_size 0;\n      proxy_set_header X-Real-IP $remote_addr;\n      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n      proxy_http_version 1.1;\n      proxy_set_header Connection &quot;&quot;;\n      error_page 400 500 502 503 504  /offline.html;\n    }\n  \n  # without compression, ssi NOT supported\n  location /compressed/example {\n    set $memcached_key &quot;$uri?$args&quot;;\n    memcached_pass memcached.port;\n    memcached_gzip_flag 2;\n    default_type text/html;\n    charset utf-8;\n    gunzip on;\n    proxy_set_header Accept-Encoding &quot;gzip&quot;;\n    error_page  404 405 400 500 502 503 504 = @compressed_fallback;\n  }\n\n  location @compressed_fallback {\n    proxy_pass http://app.port;\n    proxy_max_temp_file_size 0;\n    proxy_set_header X-Real-IP $remote_addr;\n    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n    proxy_http_version 1.1;\n    proxy_set_header Connection &quot;&quot;;\n    error_page 400 500 502 503 504  /offline.html;\n  }\n\n\n</code></pre>\n<h2>License</h2>\n<p>Apache 2</p>\n"
     },
     {
+        "deprecated": "This entry in the registry is a duplicate of the entry named 'middleware' by the same author. This entry should probably be removed to avoid confusion.",
         "bintrayPackage": {
             "name": "grails-middleware",
             "repo": "plugins",
             "owner": "lduarte",
             "desc": "Grails grails-middleware plugin",
             "labels": [
-                
+                "middleware"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/driverpt/grails-middleware/issues",
-            "latestVersion": "0.0.2",
+            "latestVersion": "0.0.3",
             "updated": "2016-03-31T13:31:56.173Z",
             "systemIds": [
+                "org.grails.plugins:middleware",
                 "org.grails.plugins:grails-middleware"
             ],
             "vcsUrl": "https://github.com/driverpt/grails-middleware"
         },
-        "documentationUrl": "https://driverpt.github.io/grails-middleware/",
+        "documentationUrl": "https://luisduarte.net/grails-middleware/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/driverpt/grails-middleware\"><img src=\"https://travis-ci.org/driverpt/grails-middleware.svg\" alt=\"Build Status\" /></a></p>\n<h1>Grails Middleware Plugin</h1>\n<p>See <a href=\"https://driverpt.github.io/grails-middleware/latest\">documentation</a> for further information.</p>\n"
     },
     {
         "bintrayPackage": {
-            "name": "grails-phonenumbers",
+            "comment": "Only Grails < 4 supported as of 0.11",
+            "name": "phonenumbers",
             "repo": "plugins",
             "owner": "ataylor284",
             "desc": "Adds support for using Google's libphonenumber library to validate phone numbers",
             "labels": [
-                
+                "validation"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2514,12 +2585,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-pretty-time",
+            "name": "pretty-time",
             "repo": "plugins",
             "owner": "cazacugmihai",
             "desc": "A plugin that allows you to display human readable, relative timestamps.",
             "labels": [
-                
+                "date"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2538,12 +2609,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-pushover",
+            "name": "pushover",
             "repo": "maven",
             "owner": "frnktrgr",
             "desc": "Provides easy access to Pushover API",
             "labels": [
-                
+                "pushover",
+                "push-notification"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2561,13 +2633,14 @@
         "readme": "<h1>grails-pushover</h1>\n<p>Provides easy access to Pushover API.</p>\n<h2>Installation</h2>\n<p>Add following line to <code>dependencies</code> section in <code>build.gradle</code>.</p>\n<pre><code class=\"language-gradle\">compile 'org.grails.plugins:pushover:1.0.1'\n</code></pre>\n<h2>Configuration</h2>\n<p>Add following lines to <code>grails-app/conf/application.yml</code>:</p>\n<pre><code class=\"language-yaml\">grails:\n\tpushover:\n\t\ttoken: &lt;API_TOKEN&gt;\n\t\tdefaultUser: &lt;DEFAULT_USER&gt;\n</code></pre>\n<p>Get your free API Token from <a href=\"https://pushover.net\">Pushover</a>.</p>\n<p>The specified <code>token</code> is used in every Pushover call if no explicit token option is given.</p>\n<p>If <code>pushoverService.message()</code> is called without a user/group token, the <code>defaultUser</code> is used.</p>\n<h2>Getting started</h2>\n<h3>Send message to default user</h3>\n<p>Send message <code>hello world</code> to <code>defaultUser</code> with configured <code>token</code> (see Configuration).</p>\n<pre><code class=\"language-groovy\">pushoverService.message(&quot;hello world&quot;)\n</code></pre>\n<h3>Send message to some user/group</h3>\n<p>Send message <code>hello world</code> to <code>&lt;USER/GROUP_TOKEN&gt;</code>.</p>\n<pre><code class=\"language-groovy\">pushoverService.message(&quot;hello world&quot;, [user: '&lt;USER/GROUP_TOKEN&gt;'])\n</code></pre>\n<h3>Send message using another API token</h3>\n<p>Send message <code>hello world</code> using <code>&lt;ANOTHER_API_TOKEN&gt;</code> API token.</p>\n<pre><code class=\"language-groovy\">pushoverService.message(&quot;hello world&quot;, [token: '&lt;ANOTHER_API_TOKEN&gt;'])\n</code></pre>\n<h2>API</h2>\n<p>All methods and options are named after their Pushover API counterparts. Please read <a href=\"https://pushover.net/api\">Pushover API</a>.</p>\n<h3>Send message</h3>\n<pre><code class=\"language-groovy\">pushoverService.message(String message, Map options=[:])\n</code></pre>\n<ul>\n<li><code>message</code>: your message</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n<li><code>user</code>: the user/group key (optional if <code>defaultUser</code> in config is set)</li>\n<li><code>device</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>title</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>url</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>url_title</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>priority</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>timestamp</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n<li><code>sound</code>: see <a href=\"https://pushover.net/api#messages\">Pushover Message API</a> (optional)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Retrieve the list of current sounds</h3>\n<pre><code class=\"language-groovy\">pushoverService.sounds(Map options=[:])\n</code></pre>\n<ul>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>User/Group verification</h3>\n<pre><code class=\"language-groovy\">pushoverService.validateUser(String user, Map options=[:])\n</code></pre>\n<ul>\n<li><code>user</code>: the user/group key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n<li><code>device</code>: see <a href=\"https://pushover.net/api\">Pushover API</a> (optional)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Retrieve information about a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groups(String group, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Adding a user to a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groupsAddUser(String group, String user, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>user</code>: user key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n<li><code>device</code>: see <a href=\"https://pushover.net/api/groups#add_user\">Pushover Groups API</a> (optional)</li>\n<li><code>memo</code>: see <a href=\"https://pushover.net/api/groups#add_user\">Pushover Groups API</a> (optional)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Removing a user from a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groupsDeleteUser(String group, String user, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>user</code>: user key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Temporarily disabling a user in a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groupsDisableUser(String group, String user, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>user</code>: user key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Re-enabling a user in a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groupsEnableUser(String group, String user, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>user</code>: user key</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<h3>Renaming a group</h3>\n<pre><code class=\"language-groovy\">pushoverService.groupsRename(String group, String name, Map options=[:])\n</code></pre>\n<ul>\n<li><code>group</code>: group key</li>\n<li><code>name</code>: new name of the group</li>\n<li><code>options</code>\n<ul>\n<li><code>token</code>: your application's API token (optional if <code>token</code> in config is set)</li>\n</ul>\n</li>\n<li>return value: map of Pushover response (see <a href=\"https://pushover.net/api#response\">https://pushover.net/api#response</a>)</li>\n</ul>\n<p>##TODOs\nSee also https://pushover.net/api</p>\n<ul>\n<li>[ ] obey limitations https://pushover.net/api#limits</li>\n<li>[ ] check response https://pushover.net/api#response</li>\n<li>[ ] Receipts and Callbacks https://pushover.net/api#receipt</li>\n<li>[ ] Being Friendly to our API https://pushover.net/api#friendly</li>\n<li>[ ] Subscription API https://pushover.net/api/subscriptions</li>\n<li>[ ] Licensing API https://pushover.net/api/licensing</li>\n</ul>\n"
     },
     {
+        "comment": "Only Grails < 4 supported as of 0.7.2",
         "bintrayPackage": {
-            "name": "grails-quick-search",
+            "name": "quick-search",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "tadodotcom",
             "desc": "\nSearch plugin for domain class properties. Lightweight plugin which puts the ability for searching, it adds utility\nfunctions for building the search result into a string format representation sufficient for auto-complete as well as\nfunctions for listing the results based on the search query.\n",
             "labels": [
-                
+                "search"
             ],
             "licenses": [
                 "BSD"
@@ -2576,8 +2649,8 @@
             "latestVersion": "0.7.2",
             "updated": "2021-02-22T10:01:03.157Z",
             "systemIds": [
-                "grails.plugin:grails-quick-search",
-                "org.grails.plugins:grails-quick-search"
+                "org.grails.plugins:grails-quick-search",
+                "grails.plugin:grails-quick-search"
             ],
             "vcsUrl": "https://github.com/tadodotcom/grails-quick-search"
         },
@@ -2586,15 +2659,15 @@
         "readme": "<h1>grails-quick-search</h1>\n<p>Grails plugin for quick search implementation. Supports search for domain class properties and adds utility functions and tag libraries for autocomplete functionality.</p>\n<p>Version 0.7.x of this plugin has been upgraded to Grails 3.1.x.</p>\n<p>See <a href=\"http://tadodotcom.github.io/grails-quick-search/guide/index.html\">documentation</a> for further information.</p>\n"
     },
     {
+        "comment": "Integration with SendGrid is outdated and does not currently seem to work.",
         "bintrayPackage": {
-            "name": "grails-sendgrid",
+            "name": "sendgrid",
             "repo": "grails-plugins",
             "owner": "desirable-objects",
             "desc": "Grails SendGrid Plugin",
             "labels": [
-                "grails",
-                "sendgrid",
-                "v3"
+                "mail",
+                "sendgrid"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2613,36 +2686,37 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-shiro",
+            "name": "shiro",
             "repo": "plugins",
             "owner": "nerderg",
             "desc": "Secure your Grails application quickly and easily using the Apache Shiro security framework.",
             "labels": [
-                
+                "security",
+                "shiro"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/nerdErg/grails-shiro/issues",
-            "latestVersion": "3.4",
-            "updated": "2021-03-11T23:54:15.035Z",
+            "latestVersion": "4.4",
+            "updated": "2021-04-18T13:56:43.000Z",
             "systemIds": [
                 "org.grails.plugins:grails-shiro"
             ],
             "vcsUrl": "https://github.com/nerdErg/grails-shiro"
         },
-        "documentationUrl": null,
+        "documentationUrl": "https://nerderg.com/docs/shiro/guide.html",
         "mavenMetadataUrl": null,
         "readme": "<div id=\"toc\" class=\"toc\">\n<div id=\"toctitle\">Table of Contents</div>\n<ul class=\"sectlevel1\">\n<li><a href=\"#_versions\">Versions</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_numbering\">Numbering</a></li>\n<li><a href=\"#_maintenance\">Maintenance</a></li>\n<li><a href=\"#_documentation_and_source\">Documentation and Source</a></li>\n</ul>\n</li>\n<li><a href=\"#_installation\">Installation</a></li>\n<li><a href=\"#_getting_started\">Getting started</a></li>\n<li><a href=\"#_version_change_log\">Version change log</a>\n<ul class=\"sectlevel2\">\n<li><a href=\"#_version_4_4\">version 4.4</a></li>\n<li><a href=\"#_version_3_3_4_3\">version 3.3 &amp; 4.3</a></li>\n<li><a href=\"#_version_4_2\">version 4.2</a></li>\n<li><a href=\"#_version_4_1\">version 4.1</a></li>\n<li><a href=\"#_version_3_1\">version 3.1</a></li>\n<li><a href=\"#_version_3_0\">version 3.0</a></li>\n</ul>\n</li>\n<li><a href=\"#_building_from_source\">Building from source</a></li>\n<li><a href=\"#_publishing\">Publishing</a></li>\n<li><a href=\"#_kudos\">Kudos</a></li>\n</ul>\n</div>\n<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p><span class=\"image\"><a class=\"image\" href=\"https://travis-ci.org/nerdErg/grails-shiro\"><img src=\"https://travis-ci.org/nerdErg/grails-shiro.svg?branch=master\" alt=\"Build Status\"></a></span></p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_versions\"><a class=\"link\" href=\"#_versions\">Versions</a></h2>\n<div class=\"sectionbody\">\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Latest <strong>released</strong> versions 3.4, 4.4</p>\n</li>\n<li>\n<p>Latest working version 3.4, 4.4 (in this repo)</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>This is the Grails Shiro plugin for grails version 4.0.x and Shiro 1.5.3. This was derived from the Grails 2.x version\n(<a href=\"https://github.com/pledbrook/grails-shiro\" class=\"bare\">https://github.com/pledbrook/grails-shiro</a>).</p>\n</div>\n<div class=\"paragraph\">\n<p>We pretty much re-wrote the plugin for Grails 3 and to simplify the use, improve the documentation and make it easier to\nmaintain. There are lots of changes please check out the\n<a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc\">Guide</a> in the docs directory.</p>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_numbering\"><a class=\"link\" href=\"#_numbering\">Numbering</a></h3>\n<div class=\"paragraph\">\n<p>In general the version number is following the Grails major version it supports, then release. e.g.</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>3.4 = Grails 3 plugin release 4\n4.4 = Grails 4 plugin release 4</pre>\n</div>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_maintenance\"><a class=\"link\" href=\"#_maintenance\">Maintenance</a></h3>\n<div class=\"paragraph\">\n<p>Although we have now published the Grails 4 version of this plugin we will continue to maintain the Grails 3 version\nbackporting features till July 2020 where possible.</p>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_documentation_and_source\"><a class=\"link\" href=\"#_documentation_and_source\">Documentation and Source</a></h3>\n<div class=\"paragraph\">\n<p>In general the documentation applies to both Grails 3 and 4 versions of the plugin. Source code including specific documentation\nfor the Grails 3 version can be found in the <strong>Grails-3 Branch</strong>.</p>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_installation\"><a class=\"link\" href=\"#_installation\">Installation</a></h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>To install, add this to your <code>build.gradle</code> dependencies for Grails 4:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>compile \"org.grails.plugins:grails-shiro:4.4\"</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>and this for Grails 3:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>compile \"org.grails.plugins:grails-shiro:3.4\"</pre>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_getting_started\"><a class=\"link\" href=\"#_getting_started\">Getting started</a></h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>If you&#8217;re implementing your security from scratch, then you can simply install grails-shiro by adding</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>compile \"org.grails.plugins:grails-shiro:4.4\"</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>to your build.gradle dependencies and typing\nshiro quick start, <a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc#shiro-quick-start\">'grails shiro-quick-start'</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>This will create a ShiroWildcardDbRealm in your <code>grails-app/realms</code> directory and make a ShiroUser and ShiroRole domain\nclass. It will also create an AuthController to let you log in. Check out\n<a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc#wildcard-db-realm\">Wildcard DB Realm</a> for how you might populate\na couple of users using Boostrap.groovy.</p>\n</div>\n<div class=\"paragraph\">\n<p>Now to Control access to a Controller add an Interceptor for that controller using\n<code><a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc#create-shiro-controller-interceptor\">grails create-shiro-controller-interceptor</a> MyController</code> which will add\n<a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc#permission-string-conventions\">access control by convention</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_version_change_log\"><a class=\"link\" href=\"#_version_change_log\">Version change log</a></h2>\n<div class=\"sectionbody\">\n<div class=\"sect2\">\n<h3 id=\"_version_4_4\"><a class=\"link\" href=\"#_version_4_4\">version 4.4</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Upgrade shiro to version 1.7.1 fixing CVE-2020-17523</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_version_3_3_4_3\"><a class=\"link\" href=\"#_version_3_3_4_3\">version 3.3 &amp; 4.3</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Fixed Annotation redirect missing context path - <a href=\"https://github.com/nerdErg/grails-shiro/issues/16\" class=\"bare\">https://github.com/nerdErg/grails-shiro/issues/16</a></p>\n</li>\n<li>\n<p>Upgrade to shiro 1.5.3</p>\n</li>\n</ul>\n</div>\n<div class=\"admonitionblock warning\">\n<table>\n<tr>\n<td class=\"icon\">\n<div class=\"title\">Warning</div>\n</td>\n<td class=\"content\">\nThis introduces a small breaking change. Annotations now use the login and unauthorized settings not URL Mappings\nto set where they redirect to.\n</td>\n</tr>\n</table>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_version_4_2\"><a class=\"link\" href=\"#_version_4_2\">version 4.2</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>upgrade to shiro 1.4.2</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_version_4_1\"><a class=\"link\" href=\"#_version_4_1\">version 4.1</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>ported to Grails version 4.0.0 (thanks Peter Legen/animator013 for you help!)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_version_3_1\"><a class=\"link\" href=\"#_version_3_1\">version 3.1</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Added ability to set the remember me cipherKey or the length of the randomly generated key</p>\n</li>\n<li>\n<p>Fix for onNotAuthenticated and onUnauthorized not working correctly (<a href=\"https://github.com/nerdErg/grails-shiro/pull/6\">Can&#8217;t be invoked on metaclass</a>)</p>\n</li>\n</ul>\n</div>\n</div>\n<div class=\"sect2\">\n<h3 id=\"_version_3_0\"><a class=\"link\" href=\"#_version_3_0\">version 3.0</a></h3>\n<div class=\"ulist\">\n<ul>\n<li>\n<p>re-write from old Grails 2 plugin see updates in the <a href=\"https://github.com/nerdErg/grails-shiro/blob/master/docs/Guide.adoc\">Guide</a></p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_building_from_source\"><a class=\"link\" href=\"#_building_from_source\">Building from source</a></h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>To build the plugin yourself and install it from this repo:</p>\n</div>\n<div class=\"olist arabic\">\n<ol class=\"arabic\">\n<li>\n<p>clone or fork this repo to your machine</p>\n</li>\n<li>\n<p>run <code>gradle install</code> and that will build, test, install it to your local maven repo (~/.m2)</p>\n</li>\n<li>\n<p>profit!</p>\n</li>\n</ol>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_publishing\"><a class=\"link\" href=\"#_publishing\">Publishing</a></h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>If you have the credentials to publish the plugin just run the <code>gradle bintrayUpload</code> task.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_kudos\"><a class=\"link\" href=\"#_kudos\">Kudos</a></h2>\n<div class=\"sectionbody\">\n<div class=\"ulist\">\n<ul>\n<li>\n<p><a href=\"https://github.com/pledbrook/grails-shiro/commits?author=pledbrook\">Peter Ledbrook</a> looking after original grails shiro plugin</p>\n</li>\n<li>\n<p><a href=\"https://github.com/pledbrook/grails-shiro/commits?author=yellowsnow\">yellowsnow</a></p>\n</li>\n<li>\n<p><a href=\"https://github.com/pledbrook/grails-shiro/commits?author=apandichi\">apandichi</a></p>\n</li>\n<li>\n<p><a href=\"https://github.com/animator013\">animator013 - Peter Legen</a></p>\n</li>\n<li>\n<p>and <a href=\"https://github.com/pledbrook/grails-shiro/graphs/contributors\">others</a> for work on the previous version of the plugin.</p>\n</li>\n</ul>\n</div>\n<div class=\"paragraph\">\n<p>Thank you to everyone who provides feedback!</p>\n</div>\n</div>\n</div>"
     },
     {
         "bintrayPackage": {
-            "name": "grails-spring-websocket",
+            "name": "spring-websocket",
             "repo": "maven",
             "owner": "zyro",
-            "desc": "",
+            "desc": "This plugin aims at making the websocket support introduced in Spring 4.0 available to Grails applications.",
             "labels": [
-                
+                "websocket"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2661,12 +2735,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-twilio",
+            "name": "twilio",
             "repo": "plugins",
             "owner": "novadge",
             "desc": "Provides SMS sending capabilities to a Grails application.",
             "labels": [
-                
+                "twilio",
+                "sms"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2675,8 +2750,8 @@
             "latestVersion": "0.1.4",
             "updated": "2016-08-13T23:01:56.281Z",
             "systemIds": [
-                "com.novadge.plugins:grails-twilio",
-                "org.grails.plugins:grails-twilio"
+                "org.grails.plugins:grails-twilio",
+                "com.novadge.plugins:grails-twilio"
             ],
             "vcsUrl": "https://github.com/Novadge/grails-twilio"
         },
@@ -2686,13 +2761,11 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails-vaadin-plugin",
+            "name": "vaadin",
             "repo": "plugins",
             "owner": "ondrej-kvasnovsky",
             "desc": "Vaadin plugin for Grails.",
             "labels": [
-                "grails",
-                "plugin",
                 "vaadin"
             ],
             "licenses": [
@@ -2711,42 +2784,40 @@
         "readme": "<p>Welcome to the official source code repository of grails-vaadin plugin.</p>\n<p><a href=\"https://www.gitbook.io/book/ondrej-kvasnovsky/vaadin-on-grails\">Vaadin on Grails Book</a></p>\n<p><a href=\"http://vaadinongrails.com\">vaadinongrails.com</a></p>\n<p><a href=\"https://twitter.com/VaadinOnGrails\">Twitter @VaadinOnGrails</a></p>\n"
     },
     {
+        "displayName": "json-views",
         "bintrayPackage": {
             "name": "grails-views",
             "repo": "plugins",
             "owner": "grails",
-            "desc": "Grails Views",
+            "desc": "Grails JSON Views",
             "labels": [
                 "json",
-                "markup",
                 "rest",
-                "views",
-                "xml"
+                "views"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-views/issues",
-            "latestVersion": "2.1.0.M4",
-            "updated": "2021-01-21T13:57:26.819Z",
+            "latestVersion": "2.3.2",
+            "updated": "2022-06-17T15:24:07.000Z",
             "systemIds": [
-                "org.grails.plugins:views-json",
-                "org.grails.plugins:views-markup"
+                "org.grails.plugins:views-json"
             ],
             "vcsUrl": "https://github.com/grails/grails-views"
         },
-        "documentationUrl": "https://grails.github.io/grails-views/",
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://views.grails.org/latest/#_json_views",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/views-json/maven-metadata.xml",
         "readme": "<h1>Grails Views</h1>\n<p>Additional View Technologies for Grails 3.0 and above.</p>\n<p>Initial implementation includes JSON views powered by Groovy's JsonBuilder, however this project provides the basis for implementation other view types.</p>\n<p>View <a href=\"https://grails.github.io/grails-views/latest/\">the latest documentation</a> for details.</p>\n<p><a href=\"https://github.com/grails/grails-views/actions/workflows/gradle.yml\"><img src=\"https://github.com/grails/grails-views/actions/workflows/gradle.yml/badge.svg?branch=master\" alt=\"Java CI\" /></a></p>\n"
     },
     {
         "bintrayPackage": {
-            "name": "grails-x-frame-options-plugin",
+            "name": "x-frame-options-plugin",
             "repo": "plugins",
             "owner": "mrhaki",
             "desc": "Servlet filter that adds a X-FRAME-OPTIONS response header",
             "labels": [
-                
+                "security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2755,6 +2826,7 @@
             "latestVersion": "1.1.0",
             "updated": "2017-03-09T10:57:09.659Z",
             "systemIds": [
+                "org.grails.plugins:x-frame-options",
                 "org.grails.plugins:grails-x-frame-options-plugin"
             ],
             "vcsUrl": "https://github.com/mrhaki/grails-x-frame-options-plugin"
@@ -2764,20 +2836,20 @@
         "readme": "<div class=\"sect1\">\n<h2 id=\"_grails_x_frame_options_plugin\">Grails X-Frame-Options Plugin</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>Filter to set HTTP response header X-Frame-Options to defend against\n<a href=\"http://en.wikipedia.org/wiki/Clickjacking\">ClickJacking</a>.</p>\n</div>\n<div class=\"paragraph\">\n<p>More information about using X-Frame-Options for defending against clickjacking:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p><a href=\"https://www.owasp.org/index.php/Clickjacking_Defense_Cheat_Sheet#Defending_with_X-Frame-Options_Response_Headers\">OWASP - Defending with X-Frame-Options response headers</a></p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_installation\">Installation</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>These instructions are targeted towards Grails 3 installations. For Grails 2.x refer to branch 1.x of the plugin.</p>\n</div>\n<div class=\"paragraph\">\n<p>Add a dependency to <code>build.gradle</code>:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>...\ndependencies {\n    ...\n    runtime ('org.grails.plugins:x-frame-options:1.1.2')\n    ...\n}\n...</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>The default configuration installs a servlet filter for the URL pattern <code>/*</code> that adds a response\nheader <code>X-Frame-Options</code> with the value <code>DENY</code>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_configuration\">Configuration</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The plugin is configured through <code>grails-app/conf/application.yml</code>.</p>\n</div>\n<div class=\"paragraph\">\n<p>We can limit the URL pattern the filter is applied to:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            urlPattern: /path/*</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>We can also set multiple patterns:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            urlPattern:\n                - /path/*\n                - /other/*</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>We can set different header values based on the configuration.\nTo set the header value <code>DENY</code> we must use the following configuration:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            deny: true</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>This is also the default value if no configuration is provided or no configuration options\nare set.</p>\n</div>\n<div class=\"paragraph\">\n<p>To set the header value <code>SAMEORIGIN</code> we must use the following configuration:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            sameOrigin: true</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>To set the header value <code>ALLOW-FROM</code> with a URL we must use the following configuration:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            allowFrom: http://www.mrhaki.com</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>To disable the filter we must use the following configuration option:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>grails:\n    plugin:\n        xframeoptions:\n            enabled: false</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>The filter is enabled by default and will use the <code>DENY</code> header value.</p>\n</div>\n</div>\n</div>"
     },
     {
+        "deprecated": "Since version 3.2.1, Grails has built-in CORS support.",
         "bintrayPackage": {
-            "name": "grails3-cors-interceptor",
+            "name": "cors-interceptor",
             "repo": "maven",
             "owner": "appcela",
             "desc": "Add Cross-Origin Resource Sharing (CORS) headers for Grails 3 applications.",
             "labels": [
-                "grails",
-                "plugin"
+                "cors"
             ],
             "licenses": [
                 "MIT"
             ],
-            "issueTrackerUrl": "",
-            "latestVersion": "v1.2.1",
+            "issueTrackerUrl": "https://github.com/appcela/grails3-cors-interceptor/issues",
+            "latestVersion": "1.2.1",
             "updated": "2017-11-07T07:26:53.951Z",
             "systemIds": [
                 "org.grails.plugins:grails3-cors-interceptor"
@@ -2790,12 +2862,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "grails3-uploadr",
+            "name": "uploadr",
             "repo": "plugins",
             "owner": "pankajtandon",
             "desc": "Plugin to upload multiple files from a web page. Uses HTML5 and CSS3",
             "labels": [
-                
+                "upload"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2819,7 +2891,8 @@
             "owner": "rpalcolea",
             "desc": "Grails plugin for displaying avatars from Gravatar",
             "labels": [
-                
+                "gravatar",
+                "image"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2840,17 +2913,18 @@
         "bintrayPackage": {
             "name": "greenmail",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "gpc",
             "desc": "Grails GreenMail Plugin",
             "labels": [
-                
+                "testing",
+                "mail"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/gpc/greenmail/issues",
-            "latestVersion": "2.0.0.RC2",
-            "updated": "2016-10-01T01:09:42.561Z",
+            "latestVersion": "2.0.0.RC3",
+            "updated": "2021-02-24T01:09:42.561Z",
             "systemIds": [
                 "org.grails.plugins:greenmail"
             ],
@@ -2867,21 +2941,21 @@
             "owner": "grails",
             "desc": "Grails Server Pages (GSP) - GSP (Grails Server Pages) - A server-side view rendering technology based on Groovy",
             "labels": [
-                
+                "views"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-gsp/issues",
-            "latestVersion": "4.1.0.M3",
+            "latestVersion": "5.2.1",
             "updated": "2020-12-14T17:07:19.180Z",
             "systemIds": [
                 "org.grails.plugins:gsp"
             ],
             "vcsUrl": "https://github.com/grails/grails-gsp"
         },
-        "documentationUrl": "https://grails.github.io/grails-gsp/",
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://gsp.grails.org/latest/guide/index.html",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/gsp/maven-metadata.xml",
         "readme": "<div id=\"preamble\">\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>This project contains the sources for GSP, the server-side view rendering technology used in <a href=\"http://grails.org\">Grails</a>.</p>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_documentation\">Documentation</h2>\n<div class=\"sectionbody\">\n<div class=\"ulist\">\n<ul>\n<li>\n<p>Latest - <a href=\"http://gsp.grails.org\" class=\"bare\">http://gsp.grails.org</a></p>\n</li>\n<li>\n<p>Latest - <a href=\"http://gsp.grails.org/latest/api\" class=\"bare\">http://gsp.grails.org/latest/api</a></p>\n</li>\n<li>\n<p>Snapshot Guide - <a href=\"http://gsp.grails.org/snapshot\" class=\"bare\">http://gsp.grails.org/snapshot</a></p>\n</li>\n<li>\n<p>Snapshot API - <a href=\"http://gsp.grails.org/snapshot\" class=\"bare\">http://gsp.grails.org/snapshot</a></p>\n</li>\n</ul>\n</div>\n</div>\n</div>"
     },
     {
@@ -2891,21 +2965,22 @@
             "owner": "bertramlabs",
             "desc": "Provides native Handlebars file support in the asset-pipeline. Easily convert .hbs or .handlebars files into javascript template caches for use with the handlebars runtime.",
             "labels": [
-                
+                "asset-pipeline",
+                "handlebars"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
-            "latestVersion": "3.3.1",
-            "updated": "2020-09-24T17:11:59.307Z",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:59.307Z",
             "systemIds": [
                 "com.bertramlabs.plugins:handlebars-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/handlebars-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -2915,7 +2990,7 @@
             "owner": "salex772",
             "desc": "Grails handlebars templates renderer plugin",
             "labels": [
-                
+                "handlebars"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2939,7 +3014,7 @@
             "owner": "budjb",
             "desc": "Grails hazelcast plugin",
             "labels": [
-                
+                "hazelcast"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2952,7 +3027,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-hazelcast"
         },
-        "documentationUrl": "https://budjb.github.io/grails-hazelcast/",
+        "documentationUrl": "https://budjb.github.io/grails-hazelcast/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-hazelcast\"><img src=\"http://img.shields.io/travis/budjb/grails-hazelcast.svg?branch=master\" alt=\"Build Status\" /></a>\n<a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\"><img src=\"http://img.shields.io/:license-apache-blue.svg\" alt=\"License\" /></a></p>\n<h1>Grails Hazelcast Plugin</h1>\n<p>See the documentation at <a href=\"https://budjb.github.io/grails-hazelcast/latest\">https://budjb.github.io/grails-hazelcast/latest</a>.</p>\n"
     },
@@ -2963,7 +3038,7 @@
             "owner": "enesakar",
             "desc": "Hazelcast Grails Integration",
             "labels": [
-                
+                "hazelcast"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -2987,16 +3062,19 @@
             "owner": "grails",
             "desc": "GORM - Grails Data Access Framework",
             "labels": [
-                
+                "database",
+                "gorm",
+                "hibernate",
+                "rdms"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "http://jira.grails.org/browse/GRAILS",
+            "issueTrackerUrl": "https://github.com/grails/grails-data-mapping/issues",
             "latestVersion": "4.3.10.7",
             "updated": "2016-10-03T14:41:45.128Z",
             "systemIds": [
-                
+                "org.grails.plugins:hibernate"
             ],
             "vcsUrl": "https://github.com/grails/grails-data-mapping"
         },
@@ -3011,7 +3089,8 @@
             "owner": "lgrignon",
             "desc": "This plugin aims to integrate Hibernate Search features to Grails in very few steps.",
             "labels": [
-                
+                "search",
+                "hibernate"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3071,8 +3150,8 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/gorm-hibernate4",
-            "latestVersion": "6.0.13",
-            "updated": "2017-12-18T17:43:08.718Z",
+            "latestVersion": "6.1.8",
+            "updated": "2017-10-27T06:58:00.000Z",
             "systemIds": [
                 "org.grails.plugins:hibernate4"
             ],
@@ -3098,15 +3177,15 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-data-mapping/issues",
-            "latestVersion": "7.1.0.M5",
-            "updated": "2021-01-21T15:40:08.942Z",
+            "latestVersion": "7.3.0",
+            "updated": "2022-06-07T17:35:39.000Z",
             "systemIds": [
                 "org.grails.plugins:hibernate5"
             ],
             "vcsUrl": "https://github.com/grails/grails-data-mapping"
         },
         "documentationUrl": "https://grails.github.io/grails-data-mapping/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/hibernate5/maven-metadata.xml",
         "readme": "<p><img src=\"https://github.com/grails/grails-data-mapping/workflows/Java%20CI/badge.svg?branch=master\" alt=\"Java CI\" />\n<img src=\"https://github.com/grails/grails-data-mapping/workflows/Release/badge.svg?branch=master\" alt=\"Release\" />\n<img src=\"https://github.com/grails/grails-data-mapping/workflows/Maven%20Central%20Sync/badge.svg?branch=master\" alt=\"Maven Central Sync\" /></p>\n<h1>GORM (Grails Object Mapping)</h1>\n<p>[Grails][Grails] is a framework used to build web applications with the [Groovy][Groovy] programming language. This project provides the plumbings for the GORM API both for Hibernate and for new implementations of GORM ontop of NoSQL datastores.\n[Grails]: http://grails.org/\n[Groovy]: http://groovy-lang.org/</p>\n<h2>Getting Started</h2>\n<p>For further information see the dedicated websites:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/\">Stable Version</a>.</li>\n<li><a href=\"http://gorm.grails.org/snapshot/\">Development Version</a>.</li>\n</ul>\n<h2>License</h2>\n<p>Grails and Groovy are licensed under the terms of the [Apache License, Version 2.0][Apache License, Version 2.0].\n[Apache License, Version 2.0]: http://www.apache.org/licenses/LICENSE-2.0.html</p>\n"
     },
     {
@@ -3116,7 +3195,7 @@
             "owner": "snimavat",
             "desc": "Html Cleaner Grails Plugin",
             "labels": [
-                
+                "html"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3134,13 +3213,14 @@
         "readme": "<p><a href=\"https://travis-ci.org/snimavat/html-cleaner\"><img src=\"https://travis-ci.org/snimavat/html-cleaner.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>See <a href=\"http://snimavat.github.com/html-cleaner/guide/index.html\">documentation</a></p>\n"
     },
     {
+        "deprecated": "Source repository is archived and this is a duplicate of a plugin with the same name by snimavat. This entry in the registry should probably be removed to avoid confusion.",
         "bintrayPackage": {
             "name": "html-cleaner",
             "repo": "plugins",
             "owner": "agorapulse",
             "desc": "Grails HTML Cleaner plugin",
             "labels": [
-                
+                "html"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3164,7 +3244,7 @@
             "owner": "grails",
             "desc": "Grails HTTP Builder Helper Plugin",
             "labels": [
-                
+                "http-client"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3188,7 +3268,7 @@
             "owner": "budjb",
             "desc": "The HTTP Requests Plugin provides the http-requests library and artefacts for filters and converters.",
             "labels": [
-                
+                "http-client"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3212,7 +3292,8 @@
             "owner": "amc-world",
             "desc": "asset-pipeline plugin to use localized messages in JavaScript.",
             "labels": [
-                
+                "i18n",
+                "javascript"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3234,10 +3315,9 @@
             "name": "i18n-enums",
             "repo": "plugins",
             "owner": "sbglasius",
-            "desc": "Successor for the Grails 2.x plugin. Now ported to Grails 3.x",
+            "desc": "This plugin adds an annotation usable on Enums to easy add and implement the MessageSourceResolvable interface in an standard way throughout a project.",
             "labels": [
                 "enums",
-                "grails",
                 "i18n"
             ],
             "licenses": [
@@ -3262,7 +3342,8 @@
             "owner": "salex772",
             "desc": "Render all Grails i18n messages to Javascript",
             "labels": [
-                
+                "i18n",
+                "javascript"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3286,7 +3367,8 @@
             "owner": "puneetbehl",
             "desc": "Grails jasper plugin",
             "labels": [
-                
+                "reporting",
+                "jasper"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3310,21 +3392,23 @@
             "owner": "9ci",
             "desc": "Jasper reports Grails Plugin - Jasper reports Grails Plugin",
             "labels": [
-                
+                "reporting",
+                "jasper"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/yakworks/grails-jasper-reports/issues",
-            "latestVersion": "3.2.0",
-            "updated": "2019-05-08T17:51:07.110Z",
+            "issueTrackerUrl": "https://github.com/yakworks/spring-grails-kit",
+            "latestVersion": "5.0.8",
+            "updated": "2022-09-29T21:48:00.000Z",
             "systemIds": [
+                "org.yakworks:grails-jasper",
                 "org.grails.plugins:jasper-reports"
             ],
-            "vcsUrl": "https://github.com/githubSlug"
+            "vcsUrl": "https://github.com/yakworks/spring-grails-kit"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/yakworks/grails-jasper/maven-metadata.xml",
         "readme": null
     },
     {
@@ -3334,7 +3418,7 @@
             "owner": "budjb",
             "desc": "The jaxrs project is a set of Grails plugins that supports the development of RESTful web services based\r\non the Java API for RESTful Web Services.\r\n\r\nThe jaxrs-core plugin provides the main functionality of the plugin. This plugin does not include an implementing JAX-RS servlet provider, however, so one of the implementation plugins should be included in projects instead.",
             "labels": [
-                
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3347,7 +3431,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-jaxrs/",
+        "documentationUrl": "https://budjb.github.io/grails-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h1>JAX-RS Plugin for Grails 3.x</h1>\n<p>See the documentation at http://budjb.github.io/grails-jaxrs/3.x/latest/.</p>\n"
     },
@@ -3358,7 +3442,8 @@
             "owner": "budjb",
             "desc": "The jaxrs project is a set of Grails plugins that supports the development of RESTful web services based\r\non the Java API for RESTful Web Services.\r\n\r\nThe jaxrs-integration-test plugin provides classes to help with integration testing.",
             "labels": [
-                
+                "testing",
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3371,7 +3456,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-jaxrs/",
+        "documentationUrl": "https://budjb.github.io/grails-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h1>JAX-RS Plugin for Grails 3.x</h1>\n<p>See the documentation at http://budjb.github.io/grails-jaxrs/3.x/latest/.</p>\n"
     },
@@ -3382,7 +3467,7 @@
             "owner": "budjb",
             "desc": "The jaxrs project is a set of Grails plugins that supports the development of RESTful web services based\r\non the Java API for RESTful Web Services.\r\n\r\nThe jaxrs-jersey1 plugin implements the Jersey 1.x JAX-RS implementation.",
             "labels": [
-                
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3395,7 +3480,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-jaxrs/",
+        "documentationUrl": "https://budjb.github.io/grails-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h1>JAX-RS Plugin for Grails 3.x</h1>\n<p>See the documentation at http://budjb.github.io/grails-jaxrs/3.x/latest/.</p>\n"
     },
@@ -3406,7 +3491,7 @@
             "owner": "budjb",
             "desc": "The jaxrs project is a set of Grails plugins that supports the development of RESTful web services based\r\non the Java API for RESTful Web Services.\r\n\r\nThe jaxrs-restlet plugin implements the Restlet JAX-RS implementation.",
             "labels": [
-                
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3419,7 +3504,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-jaxrs/",
+        "documentationUrl": "https://budjb.github.io/grails-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h1>JAX-RS Plugin for Grails 3.x</h1>\n<p>See the documentation at http://budjb.github.io/grails-jaxrs/3.x/latest/.</p>\n"
     },
@@ -3430,7 +3515,7 @@
             "owner": "budjb",
             "desc": "Integrates the Swagger UI with applications using JAX-RS resources.",
             "labels": [
-                
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3443,7 +3528,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-jaxrs/",
+        "documentationUrl": "https://budjb.github.io/grails-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h1>JAX-RS Plugin for Grails 3.x</h1>\n<p>See the documentation at http://budjb.github.io/grails-jaxrs/3.x/latest/.</p>\n"
     },
@@ -3454,7 +3539,8 @@
             "owner": "vahid",
             "desc": "Grails Jenjir plugin",
             "labels": [
-                
+                "jira",
+                "jenkins"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3490,8 +3576,8 @@
             "latestVersion": "1.2.1",
             "updated": "2017-04-19T17:22:29.457Z",
             "systemIds": [
-                "org.grails.plugins:grails-jesque",
-                "org.grails.plugins:jesque"
+                "org.grails.plugins:jesque",
+                "org.grails.plugins:grails-jesque"
             ],
             "vcsUrl": "https://github.com/Grails-Plugin-Consortium/grails-jesque"
         },
@@ -3506,7 +3592,7 @@
             "owner": "uberall",
             "desc": "Admin UI for the Grails Jesque Plugin",
             "labels": [
-                
+                "jesque"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3528,34 +3614,36 @@
         "bintrayPackage": {
             "name": "jms",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "gpc",
             "desc": "Grails jms plugin",
             "labels": [
-                "jms"
+                "jms",
+                "messaging"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/gpc/jms/issues",
             "latestVersion": "4.0.1",
-            "updated": "2021-12-26T11:24:51.000Z",
+            "updated": "2022-11-18T11:23:00.000Z",
             "systemIds": [
+                "io.github.gpc:jms",
                 "org.grails.plugins:jms"
             ],
             "vcsUrl": "https://github.com/gpc/jms"
         },
-        "documentationUrl": "https://gpc.github.io/jms/",
+        "documentationUrl": "https://gpc.github.io/jms/latest/",
         "mavenMetadataUrl": "https://repo1.maven.org/maven2/io/github/gpc/jms/maven-metadata.xml",
-        "readme": "JMS integration for Grails. See <a href=\"http://gpc.github.io/jms/latest/\">documentation</a> for more information."
+        "readme": "JMS integration for Grails. See <a href=\"https://gpc.github.io/jms/latest/\">documentation</a> for more information."
     },
     {
         "bintrayPackage": {
             "name": "joda-time",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "gpc",
             "desc": "Joda-Time Plugin",
             "labels": [
-                
+                "date"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3573,13 +3661,14 @@
         "readme": null
     },
     {
+        "deprecated": "Source repository for this entry is archived. This entry should probably be removed from the registry.",
         "bintrayPackage": {
             "name": "json-annotations-marshaller",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "tony75",
             "desc": "Grails 3 plugin for managing JSON marshalling through annotations",
             "labels": [
-                
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3588,7 +3677,7 @@
             "latestVersion": "v1.0",
             "updated": "2016-03-31T16:16:47.970Z",
             "systemIds": [
-                
+
             ],
             "vcsUrl": "https://github.com/tony75/grails3-json-annotations-marshaller"
         },
@@ -3603,7 +3692,7 @@
             "owner": "vahid",
             "desc": "Grails j2ssh plugin",
             "labels": [
-                
+                "ssh"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3627,21 +3716,21 @@
             "owner": "bertramlabs",
             "desc": "Karman is a standardized / extensible interface plugin for dealing with various cloud services including Local, S3, and Openstack.",
             "labels": [
-                
+                "cloud"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/karman-core/issues",
-            "latestVersion": "1.5.5",
-            "updated": "2021-02-02T19:47:29.412Z",
+            "latestVersion": "2.0.5",
+            "updated": "2022-09-28T02:49:11.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:karman-grails"
             ],
             "vcsUrl": "https://github.com/bertramdev/karman-core"
         },
         "documentationUrl": "https://bertramdev.github.io/karman-core/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/karman-grails/maven-metadata.xml",
         "readme": "<h1>Karman Core</h1>\n<p>Welcome to Karman. Karman is a standardized / extensible interface plugin for dealing with various cloud services.\nIn the beginning, Karman will focus on providing rock solid simplified interfaces for storing / retrieving files in the cloud.</p>\n<p>Features:</p>\n<ul>\n<li>Standardized interface for storing / retrieving files in the cloud.</li>\n<li>Easily reusable in other plugins with the immediate benefit of supporting many different storage engines.</li>\n<li>LocalStorage mode allows the same provider classes to store files locally and provides retrieval endpoint.</li>\n</ul>\n<p>Modules:</p>\n<ul>\n<li>karman-core (Core Karman API and Local storage Provider)</li>\n<li>karman-aws (Amazon S3)</li>\n<li>karman-openstack (Openstack Swift Object Store)</li>\n<li>karman-rackspace (Rackspace CDN Object Store)</li>\n<li>karman-azure (Azure Object Store)</li>\n</ul>\n<h2>Documentation</h2>\n<p>Currently the majority of the documentation is in the Grails Plugin</p>\n<p>http://bertramdev.github.io/karman</p>\n<p>The Beginnings of a GroovyDoc area also available here:</p>\n<p>http://bertramdev.github.io/karman-core</p>\n<h2>Contributions</h2>\n<p>All contributions are of course welcome as this is an ACTIVE project. Any help with regards to reviewing platform compatibility, adding more tests, and general cleanup is most welcome.\nThanks to several people for suggestions throughout development.</p>\n"
     },
     {
@@ -3651,7 +3740,7 @@
             "owner": "vahid",
             "desc": "Grails Global postal code to address resolving Plugin KML Map Boundary utilities loader editor. Postcodes restricted to customised boundaries",
             "labels": [
-                
+                "kml"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3660,9 +3749,9 @@
             "latestVersion": "0.7",
             "updated": "2019-12-10T11:12:13.918Z",
             "systemIds": [
-                "grails.kml.plugin:kml",
+                "org.grails.plugins:kml",
                 "org.grails.plugins.kml:kml",
-                "org.grails.plugins:kml"
+                "grails.kml.plugin:kml"
             ],
             "vcsUrl": "https://github.com/vahidhedayati/grails-kml-map-plugin"
         },
@@ -3677,7 +3766,7 @@
             "owner": "grails",
             "desc": "Grails LDAP Server Plugin",
             "labels": [
-                
+                "ldap"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3701,21 +3790,23 @@
             "owner": "bertramlabs",
             "desc": "LESS Compiler for the Asset-Pipeline",
             "labels": [
-                
+                "asset-pipeline",
+                "less",
+                "css"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/less-asset-pipeline/issues",
-            "latestVersion": "3.3.1",
-            "updated": "2020-09-24T17:15:59.855Z",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:59.855Z",
             "systemIds": [
                 "com.bertramlabs.plugins:less-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/bertramdev/less-asset-pipeline"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/less-asset-pipeline/maven-metadata.xml",
         "readme": "<h1>LESS Asset Pipeline</h1>\n<p><strong>MOVED</strong>: This project has moved to a sub project of the main asset-pipeline repository <a href=\"http://github.com/bertramdev/asset-pipeline\">http://github.com/bertramdev/asset-pipeline</a></p>\n<p>The <code>less-asset-pipeline</code> is a plugin that provides LESS support for the asset-pipeline static asset management plugin.</p>\n<p>For more information on how to use asset-pipeline, visit <a href=\"http://www.github.com/bertramdev/asset-pipeline\">here</a>.</p>\n<h2>Installation</h2>\n<p>Add this plugin to your classpath in gradle or dependencies list depending on how you are using it:</p>\n<pre><code class=\"language-gradle\">//Example build.gradle file\nbuildscript {\n    repositories {\n        mavenCentral()\n    }\n    dependencies {\n        classpath 'com.bertramlabs.plugins:asset-pipeline-gradle:2.5.4'\n        classpath 'com.bertramlabs.plugins:less-asset-pipeline:2.5.4'\n    }\n}\n</code></pre>\n<h2>Usage</h2>\n<p>Create files in your standard <code>assets/stylesheets</code> folder with extension <code>.less</code> or <code>.css.less</code>. You also may require other files by using the following requires syntax at the top of each file or the standard LESS import:</p>\n<pre><code class=\"language-css\">/*\n*= require test\n*= require_self\n*= require_tree .\n*/\n\n/*Or use this*/\n@import 'test'\n\n</code></pre>\n<h2>Less4j Support</h2>\n<p>This plugin now defaults to compiling your less files with less4j instead of the standard less compiler. To Turn this off you must adjust your config:</p>\n<pre><code class=\"language-gradle\">assets {\n    configOptions = [\n      less: [\n        compiler: 'standard'\n      ]\n    ]\n}\n</code></pre>\n<h2>Production</h2>\n<p>During war build your less files are compiled into css files. This is all well and good but sometimes you dont want each individual less file compiled, but rather your main base less file. It may be best to add a sub folder for those LESS files and exclude it in your precompile config...</p>\n<p>Sample Gradle Config:</p>\n<pre><code class=\"language-gradle\">  assets {\n      excludes = ['mixins/*.less']\n  }\n</code></pre>\n"
     },
     {
@@ -3725,7 +3816,7 @@
             "owner": "herrvendil",
             "desc": "Grails 3.x Plugin to integrate LightningJ into a Grails application.",
             "labels": [
-                
+                "lightning"
             ],
             "licenses": [
                 "LGPL-3.0"
@@ -3749,7 +3840,7 @@
             "owner": "grails",
             "desc": "Grails mail plugin",
             "labels": [
-                
+                "mail"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3773,13 +3864,13 @@
             "owner": "vahid",
             "desc": "mailinglist is a Grails plugin which makes use of quartz to dynamically schedule either group or specific email address contact. You create html email templates with images etc, then define time and date for this to be sent. The job is then added to quartz and set to email at given time. The queue can easily be controlled via bootstrap so that nothing is ever lost.\r\n\r\nDo you want to email a person at 11:41 pm or maybe a group of people at 2.15am? then look no further.\r\n\r\nYou can schedule an email to be scheduled and to run on a set date and time.\r\n\r\nSupports HTML emails with inline images as well as attachments has been tested on outlook and result appears to load fine.",
             "labels": [
-                
+                "mail"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/vahidhedayati/mailinglist/issues",
-            "latestVersion": "3.0.4",
+            "latestVersion": "3.0.3",
             "updated": "2017-02-18T12:05:20.775Z",
             "systemIds": [
                 "org.grails.plugins:mailinglist"
@@ -3791,13 +3882,14 @@
         "readme": "<h1>mailinglist 0.34</h1>\n<p>mailinglist is a Grails plugin which makes use of quartz to dynamically schedule either group or specific email address contact.\nYou create html email templates with images etc, then define time and date for this to be sent. The job is then added to quartz and set to email at given time.\nThe queue can easily be controlled via bootstrap so that nothing is ever lost.</p>\n<p>Do you want to email a person at 11:41 pm or maybe a group of people at 2.15am? then look no further.</p>\n<p>You can schedule an email to be scheduled and to run on a set date and time.</p>\n<p>Supports HTML emails with inline images as well as attachments has been tested on outlook and result appears to load fine.</p>\n<p>For a walk through guide on how to install this plugin goto : https://github.com/vahidhedayati/ml-test</p>\n<h2>Installation for grails 2.4+ assets based sites:</h2>\n<p>Add plugin Dependency in BuildConfig.groovy :</p>\n<pre><code class=\"language-groovy\">compile &quot;:mailinglist:0.34&quot;\n</code></pre>\n<h2>Installation for grails 3+</h2>\n<pre><code class=\"language-groovy\">compile &quot;org.grails.plugins:mailinglist:3.0.4&quot;\n</code></pre>\n<p>For grails 3 You will need to add bootstrap-datetimepicker.min.js to your grails-app/js/javascripts folder</p>\n<p>The file can be found here:</p>\n<p>https://github.com/vahidhedayati/mailinglist/tree/master/src/main/templates/js or https://tarruda.github.io/bootstrap-datetimepicker/</p>\n<h4>Under 2.4.0 you may need to review hibernate version and update to:</h4>\n<pre><code>runtime &quot;:hibernate4:4.3.5.4&quot;\n</code></pre>\n<p>Please refer to <a href=\"https://github.com/vahidhedayati/testmlist\">example site grails 2:</a></p>\n<p>Please refer to <a href=\"https://github.com/vahidhedayati/testmlist3\">example site grails 3:</a></p>\n<h2>Installation for grails &lt; 2.4 based resources sites 2.X -&gt; 2.3.X</h2>\n<p>Under Resources based application you can still use the latest code base, but you need to exclude hibernate. Something like this:</p>\n<pre><code>compile (&quot;:maillinglist:X.XX&quot;) { excludes 'hibernate' }\n</code></pre>\n<p>If you wish you could also use the very last build under compatible hibernate version built under resources:\nAdd plugin Dependency in BuildConfig.groovy :</p>\n<pre><code class=\"language-groovy\">compile &quot;:mailinglist:0.19&quot;\n</code></pre>\n<h2>Since 0.23 you also require:</h2>\n<p>In the latest app I had to also enable fixes for export plugin, unsure why it did not pull it from within plugin...</p>\n<p>Under BuildConfig.groovy:</p>\n<pre><code>\trepositories {\n\t\t......\n\t\tmavenRepo &quot;http://repo.grails.org/grails/core&quot;\n    \t}\n\n    \tdependencies {\n\t\t.....\n\t\tcompile 'commons-beanutils:commons-beanutils:1.8.3'\n    \t}\n</code></pre>\n<p>The two extra lines one to repositories and one to dependencies.</p>\n<h2>Resources based sites : (Grails pre 2.4 )  grails-app/layouts/main.gsp update:</h2>\n<h5>jquery, jquery-ui libraries:</h5>\n<p>your layouts main.gsp: (add jquery-ui and jquery  - or add them into ApplicationResources.groovy and ensure you refer to it in your main.gsp or relevant file</p>\n<pre><code class=\"language-gsp\">\t&lt;g:javascript library=&quot;jquery&quot;/&gt;\n\t&lt;g:javascript library=&quot;jquery-ui&quot;/&gt;\n\t\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\n\t\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\n\t&lt;g:layoutHead/&gt;\n\t&lt;mailinglist:loadbootstrap/&gt;\n&lt;/head&gt;\n</code></pre>\n<p>You will also notice <a href=\"mailinglist:loadbootstrap/\">mailinglist:loadbootstrap/</a> this loads up bootstrap to make modalbox work - if you already have bootstrap then change this to</p>\n<pre><code class=\"language-gsp\">&lt;mailinglist:loadplugincss/&gt;\n</code></pre>\n<p>I have found using this method of calling bootstrap within one of my projects to have caused a problem when looking at source it was loading before jquery,\nso by moving this block further below end head tag resolved the issue.</p>\n<h2>Assets based sites : (Grails 2.4+ ) grails-app/layouts/main.gsp update:</h2>\n<p>A default site just add the mailingList line below application.js to grails-app/layouts/main.gsp</p>\n<pre><code>\t&lt;asset:stylesheet src=&quot;application.css&quot;/&gt;\n        &lt;asset:javascript src=&quot;application.js&quot;/&gt;\n        &lt;mailinglist:loadbootstrap/&gt;\n</code></pre>\n<p>Or if you already have bootstrap initialised :</p>\n<pre><code>\t&lt;mailinglist:loadplugincss/&gt;\n</code></pre>\n<p>replace the loadboostrap to loadplugincss</p>\n<p>Now with that all in place open grails console or from the command line run</p>\n<pre><code>grails mlsetup org.example.com 5\n</code></pre>\n<p>Where org.example.com is your package and 5 is the amount of dynamic schedule jobs to generate,</p>\n<p>Assuming package was labelled as above org.example.com and schedule jobs as 5, install script will create</p>\n<pre><code>\nViews \t\tunder views/mailingList/_addedby.gsp\n\nJobs under \torg.example.com/ScheduleEmail0Job.groovy\n\t\t   \torg.example.com/ScheduleEmail1Job.groovy\n\t\t   \torg.example.com/ScheduleEmail2Job.groovy\n\t\t   \torg.example.com/ScheduleEmail3Job.groovy\n\t\t   \torg.example.com/ScheduleEmail4Job.groovy\n\nServices \tunder org.example.com\n\t\t\tIt will update QuartzEmailCheckerService to only schedule physical jobs ScheduleEmail[0-4]Job\n</code></pre>\n<p>The domains generated in your application extend base domains within plugin, besides this the rest of the controllers etc are pushed to your own application for you to do what you like with it.</p>\n<h4>i18n support</h4>\n<p>From 1.17 you can configure your i18n/messages_{locale}.properties to include translations for terms used within this plugin, to get the latest running terms for translation please refer to the <a href=\"https://github.com/vahidhedayati/mailinglist/wiki/i18n-terms---support\">wiki</a></p>\n<h2>Version changes</h2>\n<pre><code>0.34 @idiengaid identified issue with bulk emails and templates, earlier work from 0.32 needed additional if check around template\n0.33 @idiengaid spotted instance with missing i\n0.32 Pull request https://github.com/vahidhedayati/mailinglist/pull/5 \n\nmartofeld added some commits 5 hours ago\n @martofeld\tAdd support for using templates in the mail\t\t\t5495ef2\n @martofeld\tAvoid parsing if values are already a List + fix typo\t\t\ted30889\n @martofeld\tMissed some implementations of the new template\t\t\ta3a5601\n \n \n0.31 #3 Improvement of the mlsetup script and produced services \n\tIf you have refreshed mlsetup script as part of 0.30, its worth doing it again. This will produce tidier services.\n0.30 #3 further tidyup of cron expression rule checking\n0.29 #3 Cron expressions introduced so either send via cron schedule or specify date time\n0.28 minor change update modaldynamix to 0.28  and pluginbuddy 0.3 \n0.27 minor change update to modaldynamix ver 0.27\n0.26 Updated to 2.4.2, cleaned up end user app verification by using pluginbuddy. \n0.25 latest modaldynamix called - pop up boxes loading correctly according to screen size\n0.24 Fixed datetime issue under assets based sites.\n0.23 Latest modaldynamix plugin version used - modalboxes resized according to requirement - colour added to modalbox button callers.\n0.22 Excess css entries removed from MailingList.css - causing larger buttons and unnessary spacing issues.\n0.21 Missing jquery-ui js file manually inserted in for assets based sites.\n0.20 Release of assets version - identical to 0.19 but hibernate bumped to match assets based sites.\n0.19 last release for resources based sites. to keep upto date update your underlying site to assets\n0.18 i18n support added to services - further tidy up of contact a person page.\n0.17 Tidy up of mailSent view on main menu, added i18n support to most of the calls.\n0.16 latest ckeditor added\n0.15 mailinglist.warn.duplicate and mailinglist.warn.period added, issue with search mailingList fixed. Duplicate email warnings to same contactGroup  set to show on preview screen\n0.14 fixed pagination / export features on mailinglist page.\n0.13 issue with list - export feature was not working - format was not being passed - format now set to extension params\n0.12 Changed ckeditor to 4.4.0.0-SNAPSHOT http://jira.grails.org/browse/GPCKEDITOR-40\n0.11 Removal of non thread safe calls within QuartsStatusService ret_triggerName ret_triggerGroup ret_jobName, now returned as  map and parsed as params back in modSchedule\n0.10 more tidying up fixes to minor broken calls\n0.9 tidyup to taglib/service and gsps \n0.8 minor changes to _list1-top.gsp - called correct controller to display more information on scheduled jobs\n0.7 updates to default db table names, readme updates, correct ckeditor call for in index.gsp, giving upload feature for images \n0.6 minor fix MailingList controller save wrong parameter for categories\n0.5 minor fix gsp listing wrong domainClass in mailingList/_form.gsp\n0.4 moved out all of the manual modalbox calls and called modaldynamix plugin \n0.3 Missing images, alerts left in java scripts tut tut, contactclients gsp page had lots of bugs now fixed, scheduling looks a lot healthier.\n0.2 moved most back into actual plugin - bug with existing used schedule issues whilst attempting to schedule something for now whilst others queued.\n0.1 release - nearly everything written to clients project\n</code></pre>\n<h4>Config.groovy changes</h4>\n<p>Required <code>Config.groovy</code> configurations:</p>\n<pre><code class=\"language-groovy\">/*\n * Optional values to override DB table names for this plugin:\n * mailinglist.table.attachments='mailing_list_attachments'\n * mailinglist.table.categories='categories'\n * mailinglist.table.mailinglist='mailing_list'\n * mailinglist.table.schedule='mailing_list_schedule'\n * mailinglist.table.senders='mailing_list_senders'\n * mailinglist.table.templates='mailing_list_templates'\n * These options define if there should be a warning to confirm an email was sent to same group within defined period\n * mailinglist.warn.duplicate='Y'\n * --- Periods are:  | H for Hours | D for days | M for minutes | m for months | y for years | \n * mailinglist.warn.period='2H'\n * These are all the local tables created that in turn extend domainClasses from this plugin.\n * Check out your domainClass folder under the package you provided after you run the mlsetup command.\n */\n \n\t\n// Your date format that matches input of jquery datepicker config \n//mailinglist.dtFormat='dd/MM/yyyy HH.mm'\n\n\nckeditor {\n\t//config = &quot;/js/myckconfig.js&quot;\n\tskipAllowedItemsCheck = false\n\tdefaultFileBrowser = &quot;ofm&quot;\n\tupload {\n\t\n\t\t// basedir = &quot;/uploads/&quot;\n\t\t\n\t\tbaseurl=&quot;${grails.baseURL}&quot;+'/uploads/'\n\t\tbasedir = &quot;${externalUploadPath}&quot;\n\t\t\n\t\t\toverwrite = false\n\t\t\tlink {\n\t\t\t\tbrowser = true\n\t\t\t\tupload = false\n\t\t\t\tallowed = []\n\t\t\t\tdenied = ['html', 'htm', 'php', 'php2', 'php3', 'php4', 'php5',\n\t\t\t\t\t\t\t  'phtml', 'pwml', 'inc', 'asp', 'aspx', 'ascx', 'jsp',\n\t\t\t\t\t\t  'cfm', 'cfc', 'pl', 'bat', 'exe', 'com', 'dll', 'vbs', 'js', 'reg',\n\t\t\t\t\t\t  'cgi', 'htaccess', 'asis', 'sh', 'shtml', 'shtm', 'phtm']\n\t\t\t}\n\t\t\timage {\n\t\t\t\tbrowser = true\n\t\t\t\tupload = true\n\t\t\t\tallowed = ['jpg', 'gif', 'jpeg', 'png']\n\t\t\t\tdenied = []\n\t\t\t}\n\t\t\tflash {\n\t\t\t\tbrowser = false\n\t\t\t\tupload = false\n\t\t\t\tallowed = ['swf']\n\t\t\t\tdenied = []\n\t\t\t}\n\t}\n}\n\njqueryDateTimePicker {\n\tformat {\n\t\tjava {\n\t\t\tdatetime = &quot;dd/MM/yyyy HH.mm&quot;\n\t\t\tdate = &quot;dd/MM/yyyy&quot;\n\t\t}\n\t\tpicker {\n\t\t\tdate = &quot;'dd/mm/yy'&quot;\n\t\t\ttime = &quot;'H.mm'&quot;\n\t\t}\n\t}\n}\n\ngrails.mime.types = [ html: ['text/html','application/xhtml+xml'],\n\txml: ['text/xml', 'application/xml'],\n\ttext: 'text-plain',\n\tjs: 'text/javascript',\n\trss: 'application/rss+xml',\n\tatom: 'application/atom+xml',\n\tcss: 'text/css',\n\tcsv: 'text/csv',\n\tpdf: 'application/pdf',\n\trtf: 'application/rtf',\n\texcel: 'application/vnd.ms-excel',\n\tods: 'application/vnd.oasis.opendocument.spreadsheet',\n\tall: '*/*',\n\tjson: ['application/json','text/json'],\n\tform: 'application/x-www-form-urlencoded',\n\tmultipartForm: 'multipart/form-data'\n  ]\n</code></pre>\n<p>You will notice <code>grails.baseURL</code> externalUploadPath within ckeditor, this was done to externalise image uploads so upon a redployment the images were still available, the approach I took to this was to run values from setenv.sh within tomcat and pass this values in as variables into <code>Config.groovy</code> as per below:</p>\n<p>// configuration for plugin testing - will not be included in the plugin zip</p>\n<p>// In my tomcat setenv.sh</p>\n<pre><code class=\"language-sh\">//UPLOADLOC=&quot;$CATALINA_HOME/uploads&quot;\n//JAVA_OPTS=&quot;$JAVA_OPTS -DUPLOADLOC=$UPLOADLOC&quot;\n//HOSTNAME=$(hostname)\n//JAVA_OPTS=&quot;$JAVA_OPTS -DSERVERURL=$HOSTNAME&quot;\n</code></pre>\n<p>Produces running tomcat with the following values:</p>\n<pre><code>// -DUPLOADLOC=/opt/tomcat7/tc1/uploads\n// -DSERVERURL=my.server.com\n</code></pre>\n<p>In my <code>Config.groovy</code> at the top I have this</p>\n<pre><code class=\"language-groovy\">if (System.getProperty('UPLOADLOC')) {\n\texternalUploadPath=System.getProperty('UPLOADLOC')+File.separator\n}\nif (System.getProperty('SERVERURL')) {\n\tgrails.baseURL='http://'+System.getProperty('SERVERURL')\n} else{\n\tgrails.baseURL='http://localhost'\n}\n</code></pre>\n<p>Now those values are valid within the ckeditor configuration</p>\n<h4>Boostrap changes</h4>\n<p>An example BootStrap call to requeue outstanding or interuppted schedules is to add something like this :</p>\n<pre><code class=\"language-groovy\">import grails.plugin.mailinglist.core.ScheduleBase\n\nclass BootStrap {\n\tdef mailingListEmailService\n    def init = { servletContext -&gt;\n\t\tdef getEmails = ScheduleBase.findAllByScheduleCompleteAndScheduleCancelled(false,false)\n\t\tgetEmails.each { params -&gt;\n\t\t\tif (params.dateTime &amp;&amp; params.emailMessage) {\n\t\t\t\tprintln &quot;RESCHEDULING MAIL QUEUE ${params?.id} --       ${params?.mailFrom}---${params?.recipientToGroup}--${params?.recipientToList}&quot;\n\t\t\t\tmailingListEmailService.rescheduleit(params)\n\t\t\t}\n\t\t}\n\t}\n}\n\n</code></pre>\n<h4>addedby within forms</h4>\n<p>There is a field passed around through the application and by default it is blank, this is due to a file called <code>views/mailingList/_addedby.gsp</code></p>\n<p>Take a look at this, if your existing application has some form of user and current user is being returned via session or another method i.e. params or something then update this page to refer to this value.\nThis should fix the issue all around the site, no guarantee haha.</p>\n<h4>conf/UrlMappings.groovy &amp; plugin default holding page</h4>\n<p>If this plugin is the only purpose of your site, then simply update your url mappings to point to the holding page of this plugin:</p>\n<pre><code class=\"language-groovy\">&quot;/&quot; {\n\tcontroller = &quot;MailingList&quot;\n\taction = &quot;index&quot;\n}\n// Commented out default and put in above\n//&quot;/&quot;(view:&quot;/index&quot;)\n</code></pre>\n<p>The plugin has a menu which can be found under: <code>http://yoursite:8080/mailinglist/MailingList</code></p>\n<p>This is the main menu, the two core options on the top left hand side, Email a person and contact clients.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-menu.png\" alt=\"mailinglist menu\" /></p>\n<p>The rest of the menu are the manual methods of reviewing email list, or removing attachments etc.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-sendperson.png\" alt=\"Email a person\" />\nThis is what to expect when emailing a person</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-sendperson1.png\" alt=\"Configure schedule date time\" />\nThe now button defaults to now, other than that choose actual date time you wish to email this person.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-sent-person.png\" alt=\"When submitted\" />\nIt will just sit in that queue you can stop the job or force it play now from that same scheduling menu.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group.png\" alt=\"Contacting group\" />\nThis is the look and feel of contact group, subject is the only thing defined, everything else is clickable or uploadable. At the top are some green buttons, each one will update this form dynamically.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group1.png\" alt=\"New Template\" />\nAdding a new template, if you do not have a preset template to use for sending emails then create a new one from the first green button at the top of the page.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group2.png\" alt=\"Attach a file\" />\nThis is if you wish to attach files like documents to be sent with email.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group3.png\" alt=\"After attaching\" />\nAttachments run in iframes, so for changes to take effect on main form you need to use the close button on the top of the page.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group4.png\" alt=\"Upload Contact Group CSV\" />\nCSV Uploader which will be your group of users to contact, please note it will always miss out on the first line since on exports usually the first line is the field name</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group5.png\" alt=\"Add Sender\" />\nThe senders from group emails come from the Senders DB table, so you need to register it once set it should remain for reuse on next use.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group6.png\" alt=\"Schedule DateTime of email\" />\nSet the time you wish to email to this group, you have now selected and ticked everything else including once template was uploaded you clicked the select box to choose it which then popped open your presaved template.</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group7.png\" alt=\"Preview Group Email\" />\nSince emailing a group of people usually requires more care, there has been a preview screen added to ensure you are happy with what is being done. if so click confirm sending email otherwise click edit to go back,</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group8.png\" alt=\"Schedule menu\" />\nThis now contains our previous job which is set in a few hours plus our new job for now, we will now choose Completed schedules from the drop down to see:</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group9.png\" alt=\"Completed jobs\" />\nThis group email as completed</p>\n<p><img src=\"https://raw.github.com/vahidhedayati/ml-test/master/documentation/mailinglist-contact-group10.png\" alt=\"Mail Log on machine\" />\nThis is my email log confirming it sent an email from set email to the uploaded csv which had 3 gmail emails, it bounced cos my sendmail is not configured and just as well considering the amount of junk I been sending haha</p>\n<p>#Common Issues:\nAfter attempting to run</p>\n<pre><code>mlsetup org.example.com 5\n</code></pre>\n<p>you must referesh the project and run</p>\n<pre><code>grails refresh-dependencies\n</code></pre>\n<p>If your in ggts you may still see red asterix you can run:</p>\n<pre><code>grails clean \n</code></pre>\n<p>These are the manual command lines goto project right click grails tools, grails command wizard will help you with those or actual command prompt below just drop the grails in front of all of the above.</p>\n<p>Date Format: Trying to schedule and can not ?</p>\n<pre><code>dd/MM/yyyy HH.mm\n</code></pre>\n<p>You may see this :</p>\n<pre><code>Could not queue job please check quartz queue to ensure schedule slots are free\n</code></pre>\n<p>If you look at the console logs you will see it could not parse and it shows a date and time, look closely at the time you will find it has a : seperating the hour and mins.\nI know I should have set this as the default right :) This is the defaults sadly so please review main config and ensure your jquery date time config is set properly to match what is needed:</p>\n<pre><code class=\"language-groovy\">mailinglist.dtFormat='dd/MM/yyyy HH.mm'\njqueryDateTimePicker {\n\tformat {\n\t\tjava {\n\t\t\tdatetime = &quot;dd/MM/yyyy HH.mm&quot;\n\t\t\tdate = &quot;dd/MM/yyyy&quot;\n\t\t}\n\t\tpicker {\n\t\t\tdate = &quot;'dd/mm/yy'&quot;\n\t\t\ttime = &quot;'H.mm'&quot;\n\t\t}\n\t}\n}\n</code></pre>\n<p>This is in the main config above, but worth a remention, so if you want to set a different input type for date time,\nthen define this value in your config to match aboves config to get around the standard config which is a dot seperating hours and minutes.</p>\n<pre><code class=\"language-groovy\">mailinglist.dtFormat='dd/MM/yyyy HH.mm'\t\n</code></pre>\n<p>Ensure all of above tallies up for it all work properly</p>\n<h4>Pop up Modal boxes within contact clients</h4>\n<p>Take a look at  https://github.com/vahidhedayati/modaldynamix follow the guide then refer to pages within this plugin to get a better idea on how to use it all together.</p>\n<h2>Finally</h2>\n<p>A big thank you as always to Burt Beckwith for cleaning up the code:\nUnfortunately due to issues with merging repo was cleaned up, original code cna be found here:\nThose changes are here: https://github.com/burtbeckwith/mailinglist/</p>\n<p><a href=\"https://github.com/martofeld\">@martofeld martin</a> For adding template support to the plugin</p>\n<p><a href=\"https://github.com/stokito\">Sergey Ponomarev</a> For cleaning up and adding formating to the README.md</p>\n<p>Thank you all for you contributions. If you wish to contribute or add stuff I be happy to add you as a project member. I am no longer using this project so will not be getting much updates from me.</p>\n"
     },
     {
+        "comment": "Micronaut is part of Grails since 4.0.0. Is this entry still relevant?",
         "bintrayPackage": {
             "name": "micronaut-beans",
             "repo": "plugins",
             "owner": "grails",
             "desc": "Grails Plugin For Adding Micronaut Beans To The Spring Application Context",
             "labels": [
-                
+                "micronaut"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3812,7 +3904,7 @@
         },
         "documentationUrl": "https://grails-plugins.github.io/micronaut-beans/",
         "mavenMetadataUrl": null,
-        "readme": null
+        "readme": "https://grails-plugins.github.io/micronaut-beans/"
     },
     {
         "bintrayPackage": {
@@ -3821,7 +3913,7 @@
             "owner": "lduarte",
             "desc": "Grails middleware plugin",
             "labels": [
-                
+                "middleware"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3834,7 +3926,7 @@
             ],
             "vcsUrl": "https://github.com/driverpt/grails-middleware"
         },
-        "documentationUrl": "https://driverpt.github.io/grails-middleware/",
+        "documentationUrl": "https://driverpt.github.io/grails-middleware/latest",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/driverpt/grails-middleware\"><img src=\"https://travis-ci.org/driverpt/grails-middleware.svg\" alt=\"Build Status\" /></a></p>\n<h1>Grails Middleware Plugin</h1>\n<p>See <a href=\"https://driverpt.github.io/grails-middleware/latest\">documentation</a> for further information.</p>\n"
     },
@@ -3845,12 +3937,7 @@
             "owner": "modnsolutions",
             "desc": "Infobip SMS Grails plugin",
             "labels": [
-                "grails",
-                "groovy",
                 "infobip",
-                "java",
-                "jvm",
-                "messaging",
                 "sms"
             ],
             "licenses": [
@@ -3877,23 +3964,21 @@
             "desc": "GORM for MongoDB",
             "labels": [
                 "gorm",
-                "grails",
-                "groovylang",
                 "mongodb"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/gorm-mongodb/issues",
-            "latestVersion": "7.1.0.M4",
-            "updated": "2021-01-21T18:30:35.566Z",
+            "latestVersion": "7.3.0",
+            "updated": "2022-06-09T08:52:48.000Z",
             "systemIds": [
                 "org.grails.plugins:mongodb"
             ],
             "vcsUrl": "https://github.com/grails/gorm-mongodb"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/mongodb/maven-metadata.xml",
         "readme": "<p><img src=\"https://github.com/grails/gorm-mongodb/workflows/Java%20CI/badge.svg?branch=master\" alt=\"Java CI\" />\n<img src=\"https://github.com/grails/gorm-mongodb/workflows/Release/badge.svg?branch=master\" alt=\"Release\" /></p>\n<h1>GORM for MongoDB</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/\">GORM</a> for the MongoDB Document Database.</p>\n<p>NOTE: This source code here is for version 6.x and above. For prevoius versions' source see the relevant branch on the <a href=\"https://github.com/grails/grails-data-mapping/tree/5.x/grails-datastore-gorm-mongodb\">Grails Data Mapping project</a>.</p>\n<p>For more information see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/mongodb/manual\">Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/mongodb/api\">API</a></li>\n<li><a href=\"https://grails.org/plugins.html#plugin/mongodb\">Grails Plugin</a></li>\n</ul>\n<p>For the current development version see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/mongodb/manual\">Beta Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/mongodb/api\">Beta API</a></li>\n</ul>\n"
     },
     {
@@ -3903,7 +3988,8 @@
             "owner": "ikalizpet",
             "desc": "Mongogee is a Grails plugin for MongoDB data migration management",
             "labels": [
-                
+                "migration",
+                "mongodb"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3921,13 +4007,14 @@
         "readme": "<h1>mongogee</h1>\n<p>MongoDB data migration Grails Plugin.</p>\n<p>TravisCI <a href=\"https://travis-ci.org/binlecode/mongogee\"><img src=\"https://travis-ci.org/binlecode/mongogee.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>INTRODUCTION</h2>\n<p>Mongogee Grails plugin is a simple, secure service for mongodb data migration management.\nThis plugin is inspired by Mongobee (https://github.com/mongobee/mongobee) MongoDB data migration toolset.</p>\n<p><strong>All the credits of the annotation based migration change management logic go to the Mongobee authors.</strong></p>\n<p>This repository contains source code of Mongogee, and a testing sample host Grails application.</p>\n<h2>INSTALL</h2>\n<p>In host Grails application's build.gradle file:</p>\n<pre><code>plugins {\n\tcompile ':mongogee:$version'\n}\n</code></pre>\n<h2>PREREQUISITES</h2>\n<p>Hosting Grails application version 3.0+.</p>\n<h2>CONFIGURATION</h2>\n<p>In host Grails application grails-app/conf/application.yml</p>\n<pre><code class=\"language-yaml\">mongogee:\n    changeEnabled: true \t\t          # default is true\n    continueWithError: false \t          # default is false\n    changeLogsScanPackage: 'some.package' # required, no default value\n    lockingRetryEnabled: false            # default to true\n    lockingRetryIntervalMillis: 3000      # default to 5s\n    lockingRetryMax: 60                   # default to 120, aka 10min\n</code></pre>\n<h2>WRITE MIGRATION CHANGES</h2>\n<p>Adopting and extending Mongobee (https://github.com/mongobee/mongobee) annotations. There are two level of migration change units: change-logs (class level) and change-sets (method level).\nChange-logs can be written in either Java or Groovy. Some groovy examples are below:</p>\n<pre><code class=\"language-groovy\">@ChangeLog(order = '001')\n\tclass MongogeeTestChangeLog {\n\t\n\t    @ChangeSet(author = &quot;testuserA&quot;, id = &quot;test1&quot;, order = &quot;01&quot;)\n\t    void testChangeSet1() {\n\t        System.out.println(&quot;invoked 1&quot;)\n\t    }\n\t\n\t    @ChangeSet(author = &quot;testuserB&quot;, id = &quot;test2&quot;, order = &quot;02&quot;)\n\t    void testChangeSet2(DB db) {\n\t        System.out.println(&quot;invoked 2 with mongodb DB argument: $db&quot;)\n\t    }\n\t\n\t    @ChangeSet(author = 'testuser', id = 'test3', order = '03', runAlways = true)\n\t    void testChangeSetRunAlways() {\n\t        println 'invoke runAlways'\n\t    }\n\t\n\t    @ChangeSet(author = 'testuser', id = 'test4', order = '04')\n\t    @ChangeEnv('development')\n\t    void testChangeSetEnvDevelopment() {\n\t        println 'invoke test for env development'\n\t    }\n\t\n\t    @ChangeSet(author = 'testuser', id = 'test5', order = '05')\n\t    @ChangeEnv('test')\n\t    void testChangeSetEnvTest() {\n\t        println 'invoke test for env test'\n\t    }\n\t}\n</code></pre>\n<h2>RUN MIGRATION</h2>\n<p><strong>Version 0.9 and up:</strong> The manual line adding below is no longer needed. Mongogee migration service will be executed automatically if <code>changeEnabled</code> is set to <code>true</code> (which is also default).</p>\n<p><strong>Version 0.8 and below:</strong> Add following to init/BootStrap.groovy</p>\n<pre><code class=\"language-groovy\">class BootStrap {\n\n    MongogeeService mongogeeService\n\n    def init = { servletContext -&gt;\n        // ...\n\n        mongogeeService.execute()\n\n    }\n\n    // ...\n}\n</code></pre>\n<h2>CHANGE LOG</h2>\n<h4>v 0.9.1</h4>\n<ul>\n<li>issue-11: change entry log can intercept and save exception error information during change set invocation, and then bubble up back to main execution flow</li>\n</ul>\n<h4>v 0.9</h4>\n<ul>\n<li>issue-9: simplify hosting app to save the manual line adding in host app bootstrap.groovy</li>\n</ul>\n<h4>v 0.8</h4>\n<ul>\n<li>issue-4: add run-count support in changeEntry persistence for those repeatable changeSets</li>\n</ul>\n<h4>v 0.7 and under</h4>\n<ul>\n<li>issue-3: add loop/lock-retry ability to application start-up</li>\n</ul>\n<h2>CONTRIBUTORS</h2>\n<p>Bin Le (bin.le.code@gmail.com)</p>\n<h2>LICENSE</h2>\n<p>Apache License Version 2.0. (http://www.apache.org/licenses/)</p>\n"
     },
     {
+        "deprecated": "Since Grails 3.2 - Use GORMs built-in support for multitenancy.",
         "bintrayPackage": {
             "name": "multitenant",
             "repo": "plugins",
             "owner": "troutbird",
             "desc": null,
             "labels": [
-                
+                "multitenant"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -3942,14 +4029,14 @@
         },
         "documentationUrl": null,
         "mavenMetadataUrl": null,
-        "readme": "<p>\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd# TOC</p>\n<h1>grails-multitenant-plugin</h1>\n<p>This plugin is sponsored by <a href=\"https://ipgeolocation.io\">IP Geolocation</a>. It adds multitenant support for grails 3 applications based on hibernate filters. Tenants are resolved using spring security.</p>\n<h2>Note</h2>\n<p>Only branch grails3.0.xhibernate4 is working. Rest of branches are for GORM5 which has broken the way hibernate filters are applied. So they won't work. Also, this plugin works only for Grails 3.0 and 3.1. For later versions of grails, use GORM's built in multi-tenancy support.\nThe work on this plugin has been stopped in favor of Grails internal support for Multi-tenant architecture.</p>\n<h2>Installation</h2>\n<p>Add following dependency in build.gradle</p>\n<pre><code>compile 'org.grails.plugins:multitenant:0.1'\n</code></pre>\n<p>Add configClass attribute in application.yml under dataSource section like this:</p>\n<pre><code> configClass: org.grails.plugin.multitenant.HibernateMultitenantConfiguration \n</code></pre>\n<h1>Architecture</h1>\n<p>This plugin uses single database single schema differentiator based technique to identify tenants.</p>\n<h2>Resolving Tenant</h2>\n<p>Currently it resolves tenant using spring security. So you have to edit spring security user domain class to implement TenantIdentifier trait like this:</p>\n<pre><code>class User implements Serializable, TenantIdentifier\n</code></pre>\n<p>It add userTenantId property to User domain class and injects two closures dynamically to this domain</p>\n<h3>withTenantId</h3>\n<p>This closure executes a particular code inside its scope with a tenantId supplied as parameters even if the logged in user does not belong to that tenant. You can only execute idempotent code inside this block. If your code is query, or some other read only operation, it will execute that with supplied tenantId. If your code is going to change something in database, it will use tenantId of logged in user. Be careful . .</p>\n<pre><code>User.withTenantId(12){\n\n// Your code goes here\n\n}\n\n</code></pre>\n<h3>withoutTenantId</h3>\n<p>As the name states, you can bypass tenantId filter temporarily to do operations not specific to any tenant.</p>\n<pre><code>User.withoutTenantId(){\n\n// You code goes here\n\n</code></pre>\n<p>The code in this scope should be read only as is the case with withTenantId method above.</p>\n<h2>Multitenat Domain Classes</h2>\n<p>You have to implement Multitenant trait in all domain classes you want to be multitenant.</p>\n<pre><code>class Book implement Multitenant\n</code></pre>\n<p>This will add a property tenantId to domain class and three methods as below:</p>\n<pre><code>Long tenantId\n\n    def beforeInsert() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n\n    def beforeValidate() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n\n    def beforeUpdate() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n    \n</code></pre>\n<p>So if you want to use these methods in any of multitenant domain class, you have to reproduce above code along with your own implementation as yours will overwrite these methods.</p>\n<h2>TenantResolverService</h2>\n<p>This plugin provide TenantResolverService to your application which can be injected anywhere just like normal grails services. It provides only one method resolveTenant which provides tenantId of current user. Multitenant plugin makes extensive use of this service at various places inside the code. Multitenant filter intercepts controller actions only. If you want to do some multitenant stuff inside a service then you should call that service from controller or use withTenantId as below:</p>\n<pre><code>def tenantResolverService\nUser.withTenantId(tenantResolverService.resolveTenant()){\n // your code here\n}\n</code></pre>\n<h1>About ipgeolocation.io</h1>\n<p><a href=\"https://ipgeolocation.io\">IP Geolocation's</a> IP intelligence APIs help developer's find out Geolocation, Tim Zone, Local Currency and much more from just an IP address. For more information checkout <a href=\"https://ipgeolocation.io/documentation\">document page</a></p>\n"
+        "readme": "<p># TOC</p>\n<h1>grails-multitenant-plugin</h1>\n<p>This plugin is sponsored by <a href=\"https://ipgeolocation.io\">IP Geolocation</a>. It adds multitenant support for grails 3 applications based on hibernate filters. Tenants are resolved using spring security.</p>\n<h2>Note</h2>\n<p>Only branch grails3.0.xhibernate4 is working. Rest of branches are for GORM5 which has broken the way hibernate filters are applied. So they won't work. Also, this plugin works only for Grails 3.0 and 3.1. For later versions of grails, use GORM's built in multi-tenancy support.\nThe work on this plugin has been stopped in favor of Grails internal support for Multi-tenant architecture.</p>\n<h2>Installation</h2>\n<p>Add following dependency in build.gradle</p>\n<pre><code>compile 'org.grails.plugins:multitenant:0.1'\n</code></pre>\n<p>Add configClass attribute in application.yml under dataSource section like this:</p>\n<pre><code> configClass: org.grails.plugin.multitenant.HibernateMultitenantConfiguration \n</code></pre>\n<h1>Architecture</h1>\n<p>This plugin uses single database single schema differentiator based technique to identify tenants.</p>\n<h2>Resolving Tenant</h2>\n<p>Currently it resolves tenant using spring security. So you have to edit spring security user domain class to implement TenantIdentifier trait like this:</p>\n<pre><code>class User implements Serializable, TenantIdentifier\n</code></pre>\n<p>It add userTenantId property to User domain class and injects two closures dynamically to this domain</p>\n<h3>withTenantId</h3>\n<p>This closure executes a particular code inside its scope with a tenantId supplied as parameters even if the logged in user does not belong to that tenant. You can only execute idempotent code inside this block. If your code is query, or some other read only operation, it will execute that with supplied tenantId. If your code is going to change something in database, it will use tenantId of logged in user. Be careful . .</p>\n<pre><code>User.withTenantId(12){\n\n// Your code goes here\n\n}\n\n</code></pre>\n<h3>withoutTenantId</h3>\n<p>As the name states, you can bypass tenantId filter temporarily to do operations not specific to any tenant.</p>\n<pre><code>User.withoutTenantId(){\n\n// You code goes here\n\n</code></pre>\n<p>The code in this scope should be read only as is the case with withTenantId method above.</p>\n<h2>Multitenat Domain Classes</h2>\n<p>You have to implement Multitenant trait in all domain classes you want to be multitenant.</p>\n<pre><code>class Book implement Multitenant\n</code></pre>\n<p>This will add a property tenantId to domain class and three methods as below:</p>\n<pre><code>Long tenantId\n\n    def beforeInsert() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n\n    def beforeValidate() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n\n    def beforeUpdate() {\n        if(tenantId == null){\n            tenantId = tenantResolverService.resolveTenant()\n        }\n    }\n    \n</code></pre>\n<p>So if you want to use these methods in any of multitenant domain class, you have to reproduce above code along with your own implementation as yours will overwrite these methods.</p>\n<h2>TenantResolverService</h2>\n<p>This plugin provide TenantResolverService to your application which can be injected anywhere just like normal grails services. It provides only one method resolveTenant which provides tenantId of current user. Multitenant plugin makes extensive use of this service at various places inside the code. Multitenant filter intercepts controller actions only. If you want to do some multitenant stuff inside a service then you should call that service from controller or use withTenantId as below:</p>\n<pre><code>def tenantResolverService\nUser.withTenantId(tenantResolverService.resolveTenant()){\n // your code here\n}\n</code></pre>\n<h1>About ipgeolocation.io</h1>\n<p><a href=\"https://ipgeolocation.io\">IP Geolocation's</a> IP intelligence APIs help developer's find out Geolocation, Tim Zone, Local Currency and much more from just an IP address. For more information checkout <a href=\"https://ipgeolocation.io/documentation\">document page</a></p>\n"
     },
     {
         "bintrayPackage": {
             "name": "neo4j",
             "repo": "plugins",
             "owner": "grails",
-            "desc": "GORM - Grails Data Access Framework",
+            "desc": "GORM for Neo4j",
             "labels": [
                 "gorm",
                 "graph",
@@ -3959,15 +4046,15 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/gorm-neo4j/issues",
-            "latestVersion": "7.1.0.M4",
-            "updated": "2021-01-21T21:57:52.302Z",
+            "latestVersion": "7.3.0",
+            "updated": "2022-06-10T19:03:42.000Z",
             "systemIds": [
                 "org.grails.plugins:neo4j"
             ],
             "vcsUrl": "https://github.com/grails/gorm-neo4j"
         },
-        "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://gorm.grails.org/latest/neo4j/manual/",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/neo4j/maven-metadata.xml",
         "readme": "<h1>GORM for Neo4j</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/\">GORM</a> for the Neo4j 3.x Graph Database using the Bolt Java Driver.</p>\n<p>For more information see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/neo4j/manual\">Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/neo4j/api\">API</a></li>\n<li><a href=\"https://grails.org/plugins.html#plugin/neo4j\">Grails Plugin</a></li>\n<li><a href=\"https://travis-ci.org/grails/gorm-neo4j\"><img src=\"https://travis-ci.org/grails/gorm-neo4j.svg?branch=master\" alt=\"Build Status\" /></a></li>\n</ul>\n<p>For the current development version see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/neo4j/manual\">Beta Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/neo4j/api\">Beta API</a></li>\n</ul>\n"
     },
     {
@@ -3977,7 +4064,7 @@
             "owner": "agorapulse",
             "desc": "Grails NewRelic plugin",
             "labels": [
-                
+                "newrelic"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4001,7 +4088,6 @@
             "owner": "novadge",
             "desc": "The Novamail plug-in provides e-mail sending and retrieving capabilities to a Grails application. It is also capable of sending emails asynchronously by using a scheduled Job",
             "labels": [
-                "email",
                 "mail"
             ],
             "licenses": [
@@ -4011,8 +4097,8 @@
             "latestVersion": "0.1.8",
             "updated": "2020-05-25T03:31:08.817Z",
             "systemIds": [
-                "com.novadge.plugins:novamail",
                 "org.grails.plugins:novamail",
+                "com.novadge.plugins:novamail",
                 "novamail:novamail"
             ],
             "vcsUrl": "https://github.com/Novadge/novamail"
@@ -4022,13 +4108,14 @@
         "readme": "<h1>Novamail</h1>\n<p><a href=\"https://travis-ci.org/Novadge/novamail\"><img src=\"https://travis-ci.org/Novadge/novamail.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>Description</h2>\n<p>The Novamail plug-in provides e-mail sending and receiving capabilities to a Grails application. It is also capable of sending emails asynchronously by using a scheduled Job.</p>\n<h2>Configuration</h2>\nI recommend you add the following to application.groovy config file. Please create the file if it doesn't exist. \n<p>Add your email provider properties to grails configuration file: Example\nAssuming you want to add config for a gmail account for 'john@gmail.com' then add the following to your grails config file.</p>\n<p><code>novamail.hostProps = [</p>\n<pre><code>  [&quot;host&quot;:'imap.gmail.com'],\n  [&quot;mail.imap.host&quot;:&quot;imap.gmail.com&quot;],\n  [&quot;mail.store.protocol&quot;: &quot;imaps&quot;],\n  [&quot;mail.imap.socketFactory.class&quot;: &quot;javax.net.ssl.SSLSocketFactory&quot;],\n  [&quot;mail.imap.socketFactory.fallback&quot;: &quot;false&quot;],\n  [&quot;mail.imaps.partialfetch&quot;:&quot;false&quot;],\n  [&quot;mail.mime.address.strict&quot;: &quot;false&quot;],\n  [&quot;mail.smtp.starttls.enable&quot;: &quot;true&quot;],\n  [&quot;mail.smtp.host&quot;: &quot;smtp.gmail.com&quot;],\n  [&quot;mail.smtp.auth&quot;: &quot;true&quot;],\n  [&quot;mail.smtp.socketFactory.port&quot;: &quot;465&quot;],\n  [&quot;mail.smtp.socketFactory.class&quot;: &quot;javax.net.ssl.SSLSocketFactory&quot;],\n  [&quot;mail.smtp.socketFactory.fallback&quot;: &quot;false&quot;]\n</code></pre>\n<p>]\n</code></p>\n <code>\n novamail{\n<pre><code>       hostname= System.getenv(&quot;CS_HOSTNAME&quot;)\n       username= System.getenv(&quot;CS_USERNAME&quot;)\n       password= System.getenv(&quot;CS_PASSWORD&quot;)\n       store= System.getenv(&quot;CS_STORE&quot;)\n       \n       }\n</code></pre>\n  </code>         \n<p><small>Avoid having passwords in your code. Store them as Environment variables. </small></p>\n<h3>Side note </h3>\nNovamail will try to use predefined host props for some popular email providers if you do not provide hostProps\n<h2>Usage</h2>\n<p>Inject messagingService into your class</p>\n<p><code>def messagingService</code></p>\n<p><em>messagingService</em> is a Grails service that provides a single method called sendEmail that takes parameters.\nPlease note that 'sendEmail()' is overloaded 'see http://en.wikipedia.org/wiki/Function_overloading' and can take various variations of parameters.</p>\n<br/>\nOne simple form is:\n<code>\nsendEmail(Map map)\n</code>\n<p>Where ......</p>\n<p>map contains parameters...\nmap.to: Email recipient eg recipient@gmail.com</p>\n<p>map.subject: &quot;Your email subject&quot;</p>\n<p>map.body: &quot;The body of your message&quot;</p>\n<h2>Example</h2>\n<p>An example usage can be seen below.</p>\n<code>\n<pre><code>Class YourController{\n \n    def messagingService\n    ...\n    def yourMethod(){\n        def map = [to:&quot;recipient@gmail.com&quot;,subject:&quot;Email subject&quot;,body:&quot;email body&quot;]\n        messagingService.sendEmail(map)\n    \n    }\n\n}\n</code></pre>\n</code>\n<h1>Second form</h1>\n<h2>Requirements</h2>\n<p>To use the <code>messagingService</code> with mapped parameters, you need to declare a\nmap with the required variables. These are,\n<code>\nhostname, username, password,\nfrom, to, subject, body, html, attachments, hostProps</p>\n<p></code>.</p>\n<ul>\n<li>hostname : String</li>\n<li>username: Stiring</li>\n<li>password : String</li>\n<li>from : String </li>\n<li>to : String </li>\n<li>subject : String </li>\n<li>body : String </li>\n<li>html : boolean </li>\n<li> attachments : List<File> </li>\n</ul>\n<p><code>html</code> is boolean that defaults to <code>true</code>,</p>\n<p><code>attachments</code> is a List of type File (for file attachments) and is optional,\nand</p>\n<p><code>hostProps</code> is a map of host properties (see above). <br /></p>\n<p>If <code>hostname, username, password, from, hostProps</code> have been set in the\nConfig.groovy file, they do not have to be added to your map parameter.\n<code>html</code> defaults to <code>true</code> so that can be\nomitted as well except when set explicitly (your choice). <br /></p>\n<h2>Example Usage</h2>\n<code>\n<pre><code>Class MyController {\n    def messagingService\n    \n    def myMethod() {\n        ...\n        def map = [username:&quot;john@doe.com&quot;, password:&quot;john_password&quot;, from:&quot;JOHN Doe&lt;john@doe.com&gt;&quot;, to: &quot;recepeitn@gmail.com&quot;, subject: &quot;Hello there!&quot;, body: &quot;Just to test out awesome Novamail&quot;]\n        messagingService.sendEmail(map) // Call the messagingService sendEmail method passing in the map\n    }\n}\n</code></pre>\n</code>\n"
     },
     {
+        "deprecated": "Duplicate entry of plugin from same author. This entry should probably be removed from the registry.",
         "bintrayPackage": {
             "name": "org.grails.plugins:csv",
             "repo": "plugins",
-            "owner": "grails",
+            "owner": "vsachinv",
             "desc": "Grails CSV plugin",
             "labels": [
-                
+                "csv"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4037,7 +4124,7 @@
             "latestVersion": null,
             "updated": "2017-11-15T13:54:48.264Z",
             "systemIds": [
-                
+
             ],
             "vcsUrl": "https://github.com/vsachinv/grails-csv"
         },
@@ -4046,13 +4133,14 @@
         "readme": "<h1>grails-csv</h1>\n<p>The csv plugin provides utility methods and also support for reading/writing to csv files. It uses <code>opencsv</code> library.</p>\n<h1>Installation</h1>\n<p>Add dependency to your build.gradle for Grails 3.x:</p>\n<pre><code>repositories {\n  ...\n  maven { url &quot;http://dl.bintray.com/sachinverma/plugins&quot; }\n}\n\ndependencies {\n    compile 'org.grails.plugins:grails-csv:1.0.1'\n}\n</code></pre>\n<p>For further info: [https://github.com/vsachinv/grails-csv/wiki/Grails-CSV]</p>\n"
     },
     {
+        "deprecated": "Source repository is merged into https://github.com/grails-plugins/grails-database-migration and closed. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "org.grails.plugins:database-migration",
             "repo": "plugins",
             "owner": "yamkazu",
             "desc": "Grails database-migration plugin",
             "labels": [
-                
+                "migration"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4071,15 +4159,16 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:enforcer",
+            "name": "enforcer",
             "repo": "plugins",
             "owner": "virtualdogbert",
             "desc": "A plugin for enforcing business rules/permissions, that works with Spring Security Core, is easier to implement, and extend. It can also be used as an alternative to Spring Security ACL",
             "labels": [
-                "ACL",
-                "buisness rules",
+                "acl",
+                "business-rules",
                 "permissions",
-                "security"
+                "Security",
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4097,13 +4186,14 @@
         "readme": "<p>The Enforcer Plugin, is a lightweight, easier to maintain/extend/use, alternative to Spring Security ACL. The plugin works off of an EnforcerService and an Enforce Ast transform, The service takes up to 3 closures, a predicate, a failure(defaults to an EnforcerException if not specified) and a success(defaulted to a closure that returns true).</p>\n<p>For documentation see the github page:\n<a href=\"https://virtualdogbert.github.io/Enforcer\">documentation</a></p>\n"
     },
     {
+        "displayName": "feature-switch",
         "bintrayPackage": {
             "name": "org.grails.plugins:feature-switch",
             "repo": "grails-plugins",
             "owner": "desirable-objects",
             "desc": "Grails feature-switch plugin",
             "labels": [
-                
+
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4121,13 +4211,15 @@
         "readme": null
     },
     {
+        "deprecated": "Duplicate of geb plugin at https://github.com/grails/geb. This entry should probably be removed from the registry.",
         "bintrayPackage": {
             "name": "org.grails.plugins:geb",
             "repo": "plugins",
             "owner": "grails",
             "desc": "Grails geb plugin",
             "labels": [
-                
+                "testing",
+                "geb"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4136,7 +4228,7 @@
             "latestVersion": "1.0.1",
             "updated": "2016-04-01T15:40:48.261Z",
             "systemIds": [
-                
+                "org.grails.plugin:geb"
             ],
             "vcsUrl": "https://github.com/grails3-plugins/geb/"
         },
@@ -4146,13 +4238,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:gorm-envers",
+            "name": "gorm-envers",
             "repo": "plugins",
             "owner": "yingliang-du",
             "desc": "The gorm-envers Grails plugin add auditting functionality to GROM in your Grails application using Hibernate Envers. The only thing you need to do is add @Audited annotation to the Domain Class that you want to audit. Hibernate Envers will create audit table in the Database for the annotated domain and log all change history.",
             "labels": [
-                "grails",
-                "grails plugin"
+                "envers"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4171,12 +4262,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:grails-aws",
+            "name": "aws",
             "repo": "grails-plugins",
             "owner": "grails-aws",
             "desc": "Grails AWS Plugin",
             "labels": [
-                
+                "aws"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4194,13 +4285,15 @@
         "readme": "<h1>Amazon Web Services Grails Plugin</h1>\n<p><a href=\"https://travis-ci.org/grails-aws/grails-aws\"><img src=\"https://travis-ci.org/grails-aws/grails-aws.png?branch=master\" alt=\"Build Status\" /></a>\n<a href=\"https://coveralls.io/github/grails-aws/grails-aws?branch=master\"><img src=\"https://coveralls.io/repos/grails-aws/grails-aws/badge.svg?branch=master&amp;service=github\" alt=\"Coverage Status\" /></a></p>\n<h4>A Grails plugin for interacting with Amazon Web Services</h4>\n<p>Currently supports S3 and S3S</p>\n<h2>Getting Started</h2>\n<p>Add the plugin to the plugins section of <code>grails-app/conf/BuildConfig.groovy</code></p>\n<pre><code class=\"language-groovy\">dependencies {\n    runtime 'org.grails.plugins:grails-aws:2.0.1'\n}\n</code></pre>\n<p>Configure the plugin in <code>grails-app/conf/application.yaml</code></p>\n<pre><code class=\"language-yaml\">grails:\n    plugin:\n        aws:\n            credentials:\n                accessKey: ASDASDASDASD\n                secretKey: fASDd1h/1Hf/0pkQ+nJx+oRSm36t/R8jUI/A1D2\n            s3:\n                bucket: my-bucket\n</code></pre>\n<h2>Documentation</h2>\n<ul>\n<li><a href=\"http://grails-aws.github.io/grails-aws/1.7.5.0/\">Reference Documentation</a></li>\n<li><a href=\"http://grails-aws.github.io/grails-aws/1.7.5.0/gapi/\">Groovy Documentation</a></li>\n</ul>\n<h2>Contributing</h2>\n<ul>\n<li>Fork it.</li>\n<li>Create a branch (<code>git checkout -b my_markup</code>)</li>\n<li>Commit your changes (<code>git commit -am &quot;Added Snarkdown&quot;</code>)</li>\n<li>Push to the branch (<code>git push origin my_markup</code>)</li>\n<li>Create an <a href=\"issues/new\">Issue</a> with a link to your branch</li>\n<li>Enjoy a refreshing Diet Coke and wait</li>\n</ul>\n<h2>Changelog</h2>\n<p>2.0.1 - October 13 2015</p>\n<ul>\n<li>Grails 3.x support.</li>\n<li>Scripts are not converted yet</li>\n<li>S3 functionality only</li>\n<li>SES not tested!</li>\n</ul>\n<p>1.9.13.4 - September 11 2015</p>\n<ul>\n<li>upgrade jets3t to 0.9.1, httpclient to 4.3.2, and httpcore to 4.3.1</li>\n</ul>\n<p>1.9.13.0 - January 5 2015</p>\n<ul>\n<li>Upgrade to AWS SDK version 1.9.13</li>\n</ul>\n<p>1.7.5.0 - April 11 2014</p>\n<ul>\n<li>Upgrade to AWS SDK version 1.7.5</li>\n<li>Ability to configure SES AWS region</li>\n</ul>\n<p>1.6.7.4 - January 15 2014</p>\n<ul>\n<li>Add the ability to start SWF executions</li>\n<li>Upgrade to httpclient 4.2</li>\n</ul>\n<p>1.6.7.1 - December 10 2013</p>\n<ul>\n<li>Update to AWS SDK version 1.6.7</li>\n</ul>\n<p>1.2.12.4 - November 30 2013</p>\n<ul>\n<li>Added support to access only file metadata on S3</li>\n<li>Remove usages of the deprecated ConfigurationHolder which added warnings in grails logs</li>\n<li>Added support to specify charset for SES</li>\n</ul>\n<p>1.2.12.3 - September 30 2012</p>\n<ul>\n<li>Add support for S3 Server Side Encryption</li>\n</ul>\n<p>1.1.9.2 - May 10 2011</p>\n<ul>\n<li>Release notes: Fixed bug that was always storing the past sent mail addresses in next mail messages.</li>\n</ul>\n<h2>TODO</h2>\n<ul>\n<li>Amazon Cloudfront * Cloudfront Distribution creation</li>\n<li>Amazon SNS * Basic integration with Amazon SNS</li>\n<li>Amazon SQS * Basic integration with Amazon SQS with Typica (http://code.google.com/p/typica/wiki/TypicaSampleCode)</li>\n<li>Amazon Beanstalk * Scripts for allowing deploy directly to Amazon Beanstalk infrastructure</li>\n</ul>\n"
     },
     {
+        "comment": "There are releases for v0.2.1 and v0.2.2 but no artifacts are published.",
         "bintrayPackage": {
-            "name": "org.grails.plugins:grails-flyway",
+            "name": "flyway",
             "repo": "plugins",
             "owner": "saw303",
-            "desc": "Grails grails-flyway plugin",
+            "desc": "Grails flyway plugin",
             "labels": [
-                
+                "migration",
+                "flyway"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4218,13 +4311,14 @@
         "readme": "<h1>Flyway - Database Migration for Grails</h1>\n<p>This plugin provides <a href=\"http://flywaydb.org/\">Flyway</a> support for your Grails 3 application.</p>\n"
     },
     {
+        "deprecated": "Source repository is gone.",
         "bintrayPackage": {
             "name": "org.grails.plugins:grails-markdown",
             "repo": "grails-plugins",
             "owner": "tednaleid",
             "desc": "Grails grails-markdown plugin",
             "labels": [
-                
+                "markdown"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4243,14 +4337,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:grails3-cas-client",
+            "name": "cas-client",
             "repo": "maven",
             "owner": "cwang",
             "desc": null,
             "labels": [
-                "grails",
-                "ja-sig cas client",
-                "plugins"
+
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4269,40 +4361,39 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:grooscript",
+            "name": "grooscript",
             "repo": "grooscript",
-            "owner": "chiquitinxx",
-            "desc": "Grooscript Grails 3 Plugin",
+            "owner": "cdrchops",
+            "desc": "Grooscript Grails Plugin",
             "labels": [
-                "grails",
                 "grooscript",
                 "groovy",
-                "javascript",
-                "plugin"
+                "javascript"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/chiquitinxx/grooscript-grails3-plugin/issues",
+            "issueTrackerUrl": "https://github.com/cdrchops/grooscript-plugins/issues",
             "latestVersion": "1.3.0",
             "updated": "2017-05-19T17:34:31.179Z",
             "systemIds": [
                 "org.grails.plugins:grooscript"
             ],
-            "vcsUrl": "https://github.com/chiquitinxx/grooscript-grails3-plugin"
+            "vcsUrl": "https://github.com/cdrchops/grooscript-plugins"
         },
-        "documentationUrl": null,
+        "documentationUrl": "https://www.grooscript.org/doc.html#_grails_plugin",
         "mavenMetadataUrl": null,
         "readme": "<h1>Grooscript plugins</h1>\n<p><a href=\"https://semaphoreci.com/chiquitinxx/grooscript-plugins\"><img src=\"https://semaphoreci.com/api/v1/chiquitinxx/grooscript-plugins/branches/master/badge.svg\" alt=\"Build Status\" /></a>\n<a href=\"https://ci.appveyor.com/project/chiquitinxx/grooscript-plugins/branch/master\"><img src=\"https://ci.appveyor.com/api/projects/status/rdu67y0p9fac50pu/branch/master?svg=true\" alt=\"Build status\" /></a></p>\n<p>This is a gradle multiproject where the grooscript gradle and grails plugins sources are.</p>\n<p>More info about <a href=\"http://grooscript.org/\">grooscript</a></p>\n<h2>Multi-project</h2>\n<p>Grails 3 build, there are 5 projects:</p>\n<ul>\n<li>grails-core: library used by grooscript gradle and grails plugins</li>\n<li>grails-plugin: grooscript grails 3 plugin(*)</li>\n<li>gradle-plugin: grooscript gradle plugin(*)</li>\n<li>test-app: a grails 3 app to test the grails plugin (build from test-app-sources with gradle task createTestApp )</li>\n<li>websockets-test-app: a grails 3 app to test the grails plugin websocket features (build from websockets-test-app-sources with gradle task createWebsocketsTestApp)</li>\n</ul>\n<p>(*) published in <a href=\"https://bintray.com/chiquitinxx/grooscript\">bintray</a></p>\n<h2>TO-DO</h2>\n<ul>\n<li>Test components (how check final test? not in normal DOM).</li>\n<li>Update documentation.</li>\n</ul>\n<h2>Build</h2>\n<p>To make all checks (included geb tests using chrome remote driver if you built test apps):</p>\n<pre><code>./gradlew check\n</code></pre>\n<h2>Test jar &amp; components</h2>\n<p>To test jar generation with components, first test app must be created with:</p>\n<pre><code>./gradlew createTestApp\n</code></pre>\n<p>Later, run the test with:</p>\n<pre><code>./gradlew checkComponentInJar\n</code></pre>\n"
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:iCalendar",
+            "name": "iCalendar",
             "repo": "plugins",
             "owner": "saw303",
             "desc": "Grails iCalendar plugin",
             "labels": [
-                
+                "calendar",
+                "icalendar"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4320,13 +4411,15 @@
         "readme": null
     },
     {
+        "deprecated": "The source repository url for this entry is redirecting to the source repository of another plugin with the same name by ZenHarbinger. This entry in the registry should probably be removed to avoid confusion.",
         "bintrayPackage": {
             "name": "org.grails.plugins:jasypt-encryption",
             "repo": "grails-plugins",
             "owner": "dtanner",
             "desc": "Integration with Jasypt, allows easy encryption of information including Hibernate/GORM integration",
             "labels": [
-                
+                "encryption",
+                "jasypt"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4344,20 +4437,21 @@
         "readme": "<p>The Grails Jasypt Encryption plugin provides strong field-level encryption support on Grails GORM String fields.  It leverages the <a href=\"http://www.jasypt.org\">Jasypt</a> simplified encryption framework that makes working with the Java Cryptographic Extension (JCE) much easier.</p>\n<p>It also comes with the <a href=\"http://www.bouncycastle.org/java.html\">Bouncy Castle</a> encryption provider, which gives you access to the very secure <a href=\"http://en.wikipedia.org/wiki/Advanced_Encryption_Standard\">AES</a> algorithm.</p>\n<h3>Installation</h3>\n<pre><code>plugins {\n    compile &quot;org.grails.plugins:jasypt-encryption:x.x.x&quot;\n}\n</code></pre>\n<p>If your app is using <strong>Grails 4</strong> or higher, then use version <strong>4.0.3</strong> of this plugin.<br />\nIf your app is using <strong>Grails 3</strong> or higher, then use version <strong>2.0.2</strong> of this plugin.<br />\nIf your app is using <strong>Grails 2</strong> and <strong>Hibernate 4</strong>, then use version <strong>1.3.1</strong> of this plugin.<br />\nIf your app is using <strong>Grails 2</strong> and <strong>Hibernate 3</strong>, then use version <strong>1.2.1</strong> of this plugin.</p>\n<h3>Configuration</h3>\n<p>You'll then need to configure the encryption in your Grails configuration using a stanza like this (make sure to change the password):</p>\n<pre><code>jasypt {\n    algorithm = &quot;PBEWITHSHA256AND256BITAES-CBC-BC&quot;\n    providerName = &quot;BC&quot;\n    password = &quot;&lt;your very secret passphrase&gt;&quot;\n    keyObtentionIterations = 1000\n}\n</code></pre>\n<p>This will configure your encryption to use a 256 bit AES algorithm to do the encryption.  Key generation will also be repeated 1000 times (to slow down any brute force attacks).   Changing any of these values will result in different results (and will also prevent the ability to decrypt previously encrypted information).</p>\n<h3>External Config Files in Grails</h3>\n<p>You can put the encryption configuration in Config.groovy, but a better location would be an external configuration file that does not get checked into source code (and can vary based on environment).  Just put something like this in your Config.groovy file to define an external config file:</p>\n<pre><code>def configFIlePath = System.getenv('ENCRYPTION_CONFIG_LOCATION') ?: &quot;file:${userHome}/.jasypt&quot;\ngrails.config.locations = [configFilePath]\n</code></pre>\n<p>This enables you to set an environment variable with the location of the encryption configuration, otherwise it will look for a .encryption file in the current user's home (useful for developers).</p>\n<h3>Enabling &quot;Unlimited&quot; Encryption in Java</h3>\n<p>Because of American export standards, and the notion that <a href=\"http://en.wikipedia.org/wiki/Export_of_cryptography_in_the_United_States\">cryptographically strong algorithms are &quot;munitions&quot;</a>, you'll want to make sure that the encryption policy jars that came with your installation of Java allow &quot;unlimited&quot; encryption, rather than the default &quot;strong&quot; (which are actually pretty weak).</p>\n<p>To check to see what level of encryption your installation of Java has, you'll need to do one of two things:\nA:  Run the code from this <a href=\"https://gist.github.com/jehrhardt/5167854\">gist on github</a></p>\n<p>or</p>\n<p>B:  crack open your <code>$JAVA_HOME/jre/lib/security/local_policy.jar</code> to see what's inside.:</p>\n<pre><code>% cd /tmp\n% cp $JAVA_HOME/jre/lib/security/local_policy.jar .\n% jar xvf local_policy.jar\n inflated: META-INF/MANIFEST.MF\n inflated: META-INF/JCE_RSA.SF\n inflated: META-INF/JCE_RSA.RSA\n  created: META-INF/\n inflated: default_local.policy\n\n% cat default_local.policy\n// Country-specific policy file for countries with no limits on crypto strength.\ngrant {\n    // There is no restriction to any algorithms.\n    permission javax.crypto.CryptoAllPermission;\n};\n</code></pre>\n<p>If the permissions look like that, you're set.    Mac laptops bought in the US have this configured by default, all other installations I've seen have needed to be upgraded (including all Linux distros).</p>\n<p>Installing the new jar files is easy, just go download the &quot;Java Cryptography Extension (JCE)&quot; <a href=\"http://www.oracle.com/technetwork/java/javase/downloads/index.html\">under &quot;Other Downloads&quot; on Oracle's website</a>.</p>\n<p>Unzip the zip file and copy the jar files into your <code>$JAVA_HOME/jre/lib/security directory</code> to overwrite the existing, limited encryption jars.</p>\n<pre><code class=\"language-sh\">#make a backup copy of your existing files\nmkdir old_java_security\ncp -r $JAVA_HOME/jre/lib/security old_java_security\n\nunzip jce_policy-6.zip\nsudo cp jce/*.jar $JAVA_HOME/jre/lib/security\n</code></pre>\n<h3>Defining Fields in your Domain to Encrypt</h3>\n<p>Defining fields in your domain object that you want to be encrypted within the database is easy once the plugin is installed and configured, just define the &quot;type&quot; within the domain class' mapping:</p>\n<pre><code>package com.bloomhealthco.domain\n\nimport com.bloomhealthco.jasypt.GormEncryptedStringType\n\nclass Member {\n    String firstName\n    String lastName\n    String ssn\n    static mapping = {\n    \tssn type: GormEncryptedStringType\n    }\n}\n</code></pre>\n<p>One other caveat, if you're setting the length of the field within the database schema, you'll need to give yourself extra room as the encrypted value will be longer than the unencrypted value was.   This length will depend on the encryption algorithm that you use.  It's easy to write an integration test that can spit out all of the encrypted lengths for you.  See <code>testEncryptionWithLongNamesFit()</code> in the https://github.com/ZenHarbinger/grails-jasypt/blob/master/src/test/projects/sample/src/integration-test/groovy/com/bloomhealthco/domain/JasyptDomainEncryptionTests.groovy for an example.</p>\n<h3>Custom Encryption Types</h3>\n<p>As of version 1.1 the plugin provides 'Gorm' versions of all the built in Encrypted types provide by the jasypt plugin, http://www.jasypt.org/hibernate.html.</p>\n<p>It is also possible to define your own GORM encrypted types. This happens in two steps. First, you need a UserType that handles the encryption. This might be a class you have already from a existing java application or you could extend the jasypt class  <a href=\"https://jasypt.svn.sourceforge.net/svnroot/jasypt/trunk/jasypt-hibernate3/src/main/java/org/jasypt/hibernate3/type/AbstractEncryptedAsStringType.java\">AbstractEncryptedAsStringType</a>. Second, you define a new Gorm Encrypted type that composes that UserType to provide the wiring to the Grails configuration.</p>\n<p>Here's an example that can encrypt joda-time dates (requires the joda-time jar to work):</p>\n<pre><code>package com.bloomhealthco.jasypt\n\nimport org.jasypt.hibernate.type.AbstractEncryptedAsStringType\nimport org.joda.time.LocalDate;\n\npublic class EncryptedLocalDateAsStringType extends AbstractEncryptedAsStringType {\n\n    protected Object convertToObject(String string) {\n        if (!string) return null\n        if (!(string =~ /\\d{4}-\\d{2}-\\d{2}/)) throw new IllegalArgumentException(&quot;String does not match YYYY-MM-dd pattern&quot;)\n        new LocalDate(string)\n    }\n\n    protected String convertToString(Object object) {\n        if (!object) return null\n        if (object.class != LocalDate) throw new IllegalArgumentException(&quot;Expected ${LocalDate.name} but was ${object.class.name}&quot;)\n        object.toString(&quot;YYYY-MM-dd&quot;)\n    }\n\n    public Class returnedClass() { LocalDate }\n}\n\npublic class GormEncryptedLocalDateAsStringType extends JasyptConfiguredUserType&lt;EncryptedLocalDateAsStringType&gt; {\n}\n\n</code></pre>\n<h3>Further Documentation</h3>\n<p>For now, documentation is a little light.  There's a <a href=\"https://github.com/ZenHarbinger/grails-jasypt/tree/master/src/test/projects/sample\">test project</a> checked in as part of the repository that shows the plugin being used (and has tests that exercise the functionality).  The <a href=\"https://github.com/ZenHarbinger/grails-jasypt/blob/master/src/test/projects/sample/grails-app/domain/com/bloomhealthco/domain/Patient.groovy\">Patient domain object</a> has encrypted firstName and lastName fields on it.</p>\n<h3>Release Notes</h3>\n<ul>\n<li>4.0.3 - initial support for Grails 4</li>\n<li>2.0.1 - initial support for Grails 3</li>\n<li>1.3.1 - initial support for Hibernate 4</li>\n<li>1.2.1 - code cleanup contribution from Burt Beckwith</li>\n<li>1.2.0 - support grails 2.3.8 and up</li>\n<li>1.1.0 - Support all the encrypted UserTypes provided by jasypt's hibernate support while reusing the existing implementations; thanks to Jon Palmer for pull request &amp; work on this</li>\n<li>1.0.0 - upgraded to jasypt 1.9 - support for grails 2.0.0 thanks to pull request from Jon Palmer</li>\n<li>0.1.2 - upgraded to jasypt 1.7 - support for hibernate 3.6 and grails 1.3.6.  Could also work with earlier versions of grails but it has only been tested on 1.3.6 currently</li>\n</ul>\n"
     },
     {
+        "deprecated": "Source repository for this entry is archived. This entry should probably be removed from the registry.",
         "bintrayPackage": {
             "name": "org.grails.plugins:json-annotations-marshaller",
             "repo": "plugins",
             "owner": "anthofo",
             "desc": "Grails json-annotations-marshaller plugin",
             "labels": [
-                
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/anthofo/grails3-json-annotations-marshaller/issues",
             "latestVersion": "1.0",
-            "updated": "2021-02-12T17:14:08.309Z",
+            "updated": "2015-07-03T11:50:00.000Z",
             "systemIds": [
                 "org.grails.plugins:json-annotations-marshaller"
             ],
@@ -4369,12 +4463,12 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:log-hibernate-stats",
+            "name": "log-hibernate-stats",
             "repo": "plugins",
             "owner": "ishults",
             "desc": "A simple plugin to log Hibernate statistics across controller actions.",
             "labels": [
-                
+                "logging"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4393,12 +4487,13 @@
     },
     {
         "bintrayPackage": {
-            "name": "org.grails.plugins:quartz-monitor",
+            "name": "quartz-monitor",
             "repo": "plugins",
             "owner": "jamescookie",
             "desc": "Grails quartz-monitor plugin",
             "labels": [
-                
+                "quartz",
+                "scheduling"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4422,12 +4517,13 @@
             "owner": "grails",
             "desc": "Grails p6spy-ui plugin",
             "labels": [
-                
+                "logging",
+                "p6spy"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/p6spy-ui/issues",
+            "issueTrackerUrl": "https://github.com/burtbeckwith/grails-p6spy-ui/issues",
             "latestVersion": "3.0.0",
             "updated": "2016-04-01T15:40:04.213Z",
             "systemIds": [
@@ -4446,7 +4542,8 @@
             "owner": "novadge",
             "desc": "Accept and process payments with Paypal SDK",
             "labels": [
-                
+                "payment",
+                "paypal"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4470,7 +4567,7 @@
             "owner": "dubems",
             "desc": "Plugin to communicate with paystack API",
             "labels": [
-                
+                "payment"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4492,10 +4589,10 @@
             "name": "postgresql-extensions",
             "repo": "plugins",
             "owner": "kaleidos",
-            "desc": "This plugin provides hibernate user types to support for Postgresql Native Types like Array, HStore, JSON,\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd as well as new criterias to query this native types.",
+            "desc": "This plugin provides hibernate user types to support for Postgresql Native Types like Array, HStore, JSON as well as new criterias to query this native types.",
             "labels": [
-                "grails",
-                "postgresql"
+                "postgresql",
+                "gorm"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4519,7 +4616,7 @@
             "owner": "technipelago",
             "desc": "A plugin that allows you to create QR codes as part of your Grails application without the need for an external service",
             "labels": [
-                
+                "qrcode"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4543,7 +4640,8 @@
             "owner": "grails",
             "desc": "Grails quartz plugin",
             "labels": [
-                
+                "quartz",
+                "scheduling"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4556,7 +4654,7 @@
             ],
             "vcsUrl": "https://github.com/grails-plugins/grails-quartz"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-quartz/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-quartz/latest/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Grails Quartz Plugin</h1>\n<p><a href=\"http://grails-plugins.github.io/grails-quartz/latest/\">Latest documentation</a> and <a href=\"http://grails-plugins.github.io/grails-quartz/snapshot/\">snapshots</a> are available.</p>\n<h1>Build Status</h1>\n<p><a href=\"https://travis-ci.org/grails-plugins/grails-quartz\"><img src=\"https://travis-ci.org/grails-plugins/grails-quartz.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h2>Branches</h2>\n<p>The current master branch is for 2.x versions of the plugin compatible with Grails 3. There is a 1.x branch for on-going maintenance of 1.x versions of the plugin compatible with Grails 2. Please submit any pull requests to the appropriate branch. Changes to the 1.x branch will be merged into the master branch if appropriate.</p>\n<h2>Using</h2>\n<h3>Quick start</h3>\n<p>To start using Quartz plugin just simply add <code>compile 'org.grails.plugins:quartz:2.0.1'</code> in your <code>build.gradle</code>.</p>\n<h5>2.0.13 for Grails 3.3.*</h5>\n<p>Properties changed to <code>static</code> from <code>def</code>.<br>For example:\n<code>def concurrent</code> will be now <code>static concurrent</code>.</p>\n<h3>Scheduling Jobs</h3>\n<p>To create a new job run the <code>grails create-job</code> command and enter the name of the job. Grails will create a new job and place it in the <code>grails-app/jobs</code> directory:</p>\n<pre><code>package com.mycompany.myapp\n\nclass MyJob {\n\n    static triggers = {\n        simple repeatInterval: 1000\n    }\n\n    void execute() {\n        print &quot;Job run!&quot;\n    }\n}\n</code></pre>\n<p>The above example will call the 'execute' method every second.</p>\n<h3>Scheduling configuration syntax</h3>\n<p>Currently plugin supports three types of <a href=\"http://quartz-scheduler.org/documentation/quartz-2.x/tutorials/tutorial-lesson-02\">triggers</a>:</p>\n<ul>\n<li><strong>simple trigger</strong> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd executes once per defined interval (ex. &quot;every 10 seconds&quot;);</li>\n<li><strong>cron trigger</strong> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd executes job with cron expression (ex. &quot;at 8:00 am every Monday through Friday&quot;);</li>\n<li><strong>custom trigger</strong> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd your implementation of <a href=\"http://www.quartz-scheduler.org/api/2.2.0/org/quartz/Trigger.html\">Trigger</a> interface.</li>\n</ul>\n<p>Multiple triggers per job are allowed.</p>\n<pre><code>class MyJob {\n\n    static triggers = {\n        simple name: 'simpleTrigger', startDelay: 10000, repeatInterval: 30000, repeatCount: 10\n        cron name:   'cronTrigger',   startDelay: 10000, cronExpression: '0/6 * 15 * * ?'\n        custom name: 'customTrigger', triggerClass: MyTriggerClass, myParam: myValue, myAnotherParam: myAnotherValue\n    }\n\n    void execute() {\n        println &quot;Job run!&quot;\n    }\n}\n</code></pre>\n<p>With this configuration job will be executed 11 times with 30 seconds interval with first run in 10 seconds after\nscheduler startup (simple trigger), also it'll be executed each 6 second during 15th hour\n(15:00:00, 15:00:06, 15:00:12, ... \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd this configured by cron trigger) and also it'll be executed each time your custom\ntrigger will fire.</p>\n<p>Three kinds of triggers are supported with the following parameters. The name field must be unique:</p>\n<ul>\n<li><code>simple</code>:\n<ul>\n<li><code>name</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd the name that identifies the trigger;</li>\n<li><code>startDelay</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd delay (in milliseconds) between scheduler startup and first job's execution;</li>\n<li><code>repeatInterval</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd timeout (in milliseconds) between consecutive job's executions;</li>\n<li><code>repeatCount</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd trigger will fire job execution <code>(1 + repeatCount)</code> times and stop after that (specify <code>0</code>  here to have one-shot job or <code>-1</code> to repeat job executions indefinitely);</li>\n</ul>\n</li>\n<li><code>cron</code>:\n<ul>\n<li><code>name</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd the name that identifies the trigger;</li>\n<li><code>startDelay</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd delay (in milliseconds) between scheduler startup and first job's execution;</li>\n<li><code>cronExpression</code> \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd <a href=\"http://www.quartz-scheduler.org/api/2.2.0/org/quartz/CronExpression.html\">cron expression</a></li>\n</ul>\n</li>\n<li><code>custom</code>:\n<ul>\n<li><code>triggerClass</code>  \ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd\ufffd your class which implements <a href=\"http://www.quartz-scheduler.org/api/2.2.0/org/quartz/impl/triggers/CalendarIntervalTriggerImpl.html\">CalendarIntervalTriggerImpl</a> impl;</li>\n<li>any params needed by your trigger.</li>\n</ul>\n</li>\n</ul>\n<h3>Configuration plugin syntax</h3>\n<p>You can add the following properties to control persisteance or not persistence:</p>\n<ul>\n<li>quartz.pluginEnabled - defaults to true, can disable plugin for test cases etc</li>\n<li>quartz.jdbcStore - true to enable database store, false to use RamStore (default true)</li>\n<li>quartz.autoStartup - delays jobs until after bootstrap startup phase (default false)</li>\n<li>quartz.jdbcStoreDataSource - jdbc data source alternate name</li>\n<li>quartz.waitForJobsToCompleteOnShutdown - wait for jobs to complete on shutdown (default true)</li>\n<li>quartz.exposeSchedulerInRepository - expose Schedule in repository</li>\n<li>quartz.scheduler.instanceName - name of the scheduler to avoid conflicts between apps</li>\n<li>quartz.purgeQuartzTablesOnStartup - when jdbcStore set to 'true' and this is true, clears out all quartz tables on startup</li>\n</ul>\n"
     },
@@ -4567,7 +4665,8 @@
             "owner": "9ci",
             "desc": "Quartz Config Scheduler - Allow creating quartz job from configuration",
             "labels": [
-                
+                "quartz",
+                "scheduling"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4591,13 +4690,9 @@
             "owner": "vahid",
             "desc": "Queuekit is a plugin for grails which uses TaskExecutor with Spring Events for grails 2 and for grails 3 using default `Reactor` events to manage concurrent submitted reports.",
             "labels": [
-                "grails",
-                "grails plugin",
-                "grails queue-kit plugin",
-                "Queue reports",
-                "queuekit",
-                "report scheduling",
-                "TaskExecutor"
+                "reporting",
+                "scheduling",
+                "queue"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4621,9 +4716,8 @@
             "owner": "vahid",
             "desc": "Queuemail plugin is a centralised email queueing system configurable for many providers all  centrally controlled and limited to either daily limit or failures exceeding failureTolerance  limit (in a row). By default all email's passing through are priority driven and configured by overall  customService name.  Two methods of priority queueing are provided BASIC and ENHANCED (default).   Enhanced launches an additional thread for each running task and will attempt to kill any running process  considered as stuck (if time taken exceeds killLongRunningTasks configuration period). ",
             "labels": [
-                "grails queuemail",
                 "mail",
-                "queuemail"
+                "queue"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4647,13 +4741,13 @@
             "owner": "puneetbehl",
             "desc": "The RabbitMQ plugin provides integration with the RabbitMQ Messaging System.",
             "labels": [
-                "Grails 3",
+                "messaging",
                 "rabbitmq"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "http://jira.codehaus.org/browse/GRAILSPLUGINS",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-rabbitmq/issues",
             "latestVersion": "2.0.0",
             "updated": "2016-03-31T13:31:54.773Z",
             "systemIds": [
@@ -4670,9 +4764,8 @@
             "name": "rabbitmq-native",
             "repo": "grails-plugins",
             "owner": "budjb",
-            "desc": "A messaging plugin for Grails 3 using RabbitMQ.\r\n\r\nThis plugin gives application authors a powerful framework to quickly get a scalable messaging solution running quickly.",
+            "desc": "A messaging plugin for Grails using RabbitMQ.\r\n\r\nThis plugin gives application authors a powerful framework to quickly get a scalable messaging solution running quickly.",
             "labels": [
-                "grails",
                 "messaging",
                 "rabbitmq"
             ],
@@ -4680,7 +4773,7 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/budjb/grails-rabbitmq-native/issues",
-            "latestVersion": "3.5.1",
+            "latestVersion": "4.0.0",
             "updated": "2019-09-18T14:54:18.779Z",
             "systemIds": [
                 "org.grails.plugins:rabbitmq-native"
@@ -4692,6 +4785,7 @@
         "readme": "<div class=\"paragraph\">\n<p>RabbitMQ Native plugin for Grails</p>\n</div>\n<div class=\"paragraph\">\n<p><a href=\"http://budjb.github.io/grails-rabbitmq-native/4.x/latest\">Documentation</a></p>\n</div>"
     },
     {
+        "deprecated": "Source repository is archived.",
         "bintrayPackage": {
             "name": "recaptcha",
             "repo": "plugins",
@@ -4699,7 +4793,7 @@
             "desc": "Grails 3 ReCaptcha and MailHide plugin",
             "labels": [
                 "mailhide",
-                "recaptcha"
+                "captcha"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4723,7 +4817,9 @@
             "owner": "snimavat",
             "desc": "Recaptcha support for Spring security",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "captcha"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4744,10 +4840,10 @@
         "bintrayPackage": {
             "name": "redis",
             "repo": "grails-plugins",
-            "owner": "ctoestreich",
+            "owner": "grails",
             "desc": "Grails Redis plugin",
             "labels": [
-                
+                "redis"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4779,14 +4875,14 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/gorm-redis/issues",
-            "latestVersion": "5.0.13",
-            "updated": "2017-03-21T12:03:01.274Z",
+            "latestVersion": "6.0.4",
+            "updated": "2016-11-07T00:17:00.000Z",
             "systemIds": [
                 "org.grails.plugins:redis-gorm"
             ],
             "vcsUrl": "https://github.com/grails/gorm-redis"
         },
-        "documentationUrl": null,
+        "documentationUrl": "https://gorm.grails.org/latest/redis/manual/",
         "mavenMetadataUrl": null,
         "readme": "<h1>GORM for Redis</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/\">GORM</a> for the Redis Key/Value Database.</p>\n<p>For more information see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/redis/manual\">Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/redis/api\">API</a></li>\n<li><a href=\"https://grails.org/plugins.html#plugin/redis\">Grails Plugin</a></li>\n<li><a href=\"https://travis-ci.org/grails/gorm-redis\"><img src=\"https://travis-ci.org/grails/gorm-redis.svg?branch=master\" alt=\"Build Status\" /></a></li>\n</ul>\n<p>For the current development version see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/redis/manual\">Beta Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/redis/api\">Beta API</a></li>\n</ul>\n"
     },
@@ -4797,7 +4893,9 @@
             "owner": "neilab",
             "desc": "Remora is a Grails Image / File Upload Plugin formally based on Selfie plugin. Use Remora to attach files to your domain models, upload to a CDN, validate content, produce thumbnails.",
             "labels": [
-                
+                "image",
+                "file",
+                "upload"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4821,7 +4919,7 @@
             "owner": "amitjain",
             "desc": "Grails remote-pagination plugin",
             "labels": [
-                
+                "pagination"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4845,7 +4943,7 @@
             "owner": "vahid",
             "desc": "Grails RemoteSSH Plugin",
             "labels": [
-                
+                "ssh"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4869,7 +4967,9 @@
             "owner": "grails",
             "desc": "Grails rendering plugin",
             "labels": [
-                
+                "rendering",
+                "image",
+                "pdf"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4893,7 +4993,7 @@
             "owner": "nobeans",
             "desc": "Grails request-tracelog plugin",
             "labels": [
-                
+                "logging"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4917,7 +5017,9 @@
             "owner": "troutbird",
             "desc": null,
             "labels": [
-                
+                "pagination",
+                "rest",
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4941,7 +5043,8 @@
             "owner": "bertramlabs",
             "desc": "Adds retina resolution image tag support for asset-pipeline.",
             "labels": [
-                
+                "image",
+                "retina"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -4981,11 +5084,12 @@
             ],
             "vcsUrl": "https://github.com/grails/gorm-rest-client"
         },
-        "documentationUrl": null,
+        "documentationUrl": "http://gorm.grails.org/latest/rx/rest-client/manual/",
         "mavenMetadataUrl": null,
         "readme": "<h1>RxGORM REST Client</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/rx\">RxGORM</a> for REST web services.</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/rx/rest-client/manual/\">Latest Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/rx/rest-client/api/\">Latest API</a></li>\n</ul>\n<p>The snapshot documentation is available here:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/rx/rest-client/manual/\">Snapshot Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/rx/rest-client/api/\">Snapshot API</a></li>\n<li><a href=\"https://travis-ci.org/grails/gorm-rest-client\"><img src=\"https://travis-ci.org/grails/gorm-rest-client.svg?branch=master\" alt=\"Build Status\" /></a></li>\n</ul>\n"
     },
     {
+        "comment": "Hard to tell versions to use here. According to https://gorm.grails.org/latest/rx/manual/ it is 7.3.2 but the latest release of this plugin is 6.1.7",
         "bintrayPackage": {
             "name": "rx-mongodb",
             "repo": "plugins",
@@ -5007,7 +5111,7 @@
             ],
             "vcsUrl": "https://github.com/grails/gorm-mongodb"
         },
-        "documentationUrl": null,
+        "documentationUrl": "https://gorm.grails.org/latest/rx/manual/",
         "mavenMetadataUrl": null,
         "readme": "<p><img src=\"https://github.com/grails/gorm-mongodb/workflows/Java%20CI/badge.svg?branch=master\" alt=\"Java CI\" />\n<img src=\"https://github.com/grails/gorm-mongodb/workflows/Release/badge.svg?branch=master\" alt=\"Release\" /></p>\n<h1>GORM for MongoDB</h1>\n<p>This project implements <a href=\"http://gorm.grails.org/latest/\">GORM</a> for the MongoDB Document Database.</p>\n<p>NOTE: This source code here is for version 6.x and above. For prevoius versions' source see the relevant branch on the <a href=\"https://github.com/grails/grails-data-mapping/tree/5.x/grails-datastore-gorm-mongodb\">Grails Data Mapping project</a>.</p>\n<p>For more information see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/latest/mongodb/manual\">Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/latest/mongodb/api\">API</a></li>\n<li><a href=\"https://grails.org/plugins.html#plugin/mongodb\">Grails Plugin</a></li>\n</ul>\n<p>For the current development version see the following links:</p>\n<ul>\n<li><a href=\"http://gorm.grails.org/snapshot/mongodb/manual\">Beta Documentation</a></li>\n<li><a href=\"http://gorm.grails.org/snapshot/mongodb/api\">Beta API</a></li>\n</ul>\n"
     },
@@ -5018,7 +5122,8 @@
             "owner": "grails",
             "desc": "A plugin that integrates Grails with RxJava",
             "labels": [
-                
+                "async",
+                "rxjava"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5042,7 +5147,8 @@
             "owner": "grails",
             "desc": "A plugin that integrates Grails with RxJava",
             "labels": [
-                
+                "async",
+                "rxjava2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5055,18 +5161,19 @@
             ],
             "vcsUrl": "https://github.com/grails-plugins/grails-rxjava"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-rxjava/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-rxjava/latest/",
         "mavenMetadataUrl": null,
         "readme": "<h1>RxJava for Grails</h1>\n<p><a href=\"https://github.com/ReactiveX/RxJava\">RxJava</a> is a popular library for composing asynchronous and event-based programs by using observable sequences.</p>\n<p>RxJava helps you build reactive applications and an increasing number of libraries take advantage of RxJava as the defacto standard for building Reactive applications.</p>\n<p>In <a href=\"http://gorm.grails.org/6.0.x\">GORM 6.0</a>, a new implementation of GORM called <a href=\"http://gorm.grails.org/6.0.x/rx/manual\">RxGORM</a> has been introduced that builds on RxJava helping you building reactive data access logic using the familiar GORM API combined with RxJava.</p>\n<p>This plugin helps integrate RxJava with the controller layer of Grails to complete the picture and enable complete end-to-end integration of RxJava with Grails.</p>\n<h2>Installation</h2>\n<p>To install the plugin declare a dependency in <code>build.gradle</code>:</p>\n<pre><code class=\"language-groovy\">dependencies {\n    ...\n    compile 'org.grails.plugins:rxjava:{version}'\n}\n</code></pre>\n<p>Where <code>{version}</code> is the version of the plugin.</p>\n<h2>Documentation</h2>\n<p>For further information see the the <a href=\"http://grails-plugins.github.io/grails-rxjava/latest/\">User guide</a>.</p>\n"
     },
     {
+        "deprecated": "Duplicate entry of plugin with name 'csv' from the same author. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "sachinverma.plugins:csv",
             "repo": "plugins",
             "owner": "sachinverma",
             "desc": "Grails csv plugin",
             "labels": [
-                
+                "csv"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5090,7 +5197,9 @@
             "owner": "bertramlabs",
             "desc": "Provides fast and easy .sass and .scss file support for Transpiling to CSS. This plugin takes advantage of jsass and libsass for maximum performance.",
             "labels": [
-                
+                "asset-pipeline",
+                "sass",
+                "css"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5104,7 +5213,7 @@
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/sass-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -5114,14 +5223,14 @@
             "owner": "grails",
             "desc": "The Grails\u00ae framework Scaffolding plugin replicates much of the functionality from Grails 2, but uses the fields plugin instead.",
             "labels": [
-                
+                "scaffolding"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/scaffolding/issues",
             "latestVersion": "4.1.0",
-            "updated": "2021-12-26T19:24:37.000Z",
+            "updated": "2022-02-24T19:24:37.000Z",
             "systemIds": [
                 "org.grails.plugins:scaffolding"
             ],
@@ -5132,13 +5241,15 @@
         "readme": null
     },
     {
+        "deprecated": "Source repository is archived.",
         "bintrayPackage": {
             "name": "schwartz",
             "repo": "grails-plugins",
             "owner": "agileorbit",
             "desc": "Quartz integration",
             "labels": [
-                
+                "quartz",
+                "scheduling"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5159,26 +5270,24 @@
         "bintrayPackage": {
             "name": "schwartz-monitor",
             "repo": "plugins",
-            "owner": "robertoschwald",
-            "desc": "Grails 3 Plugin to Monitor Schwartz- or Quartz Plugin Jobs",
+            "owner": "symentis",
+            "desc": "Grails Plugin to Monitor Schwartz- or Quartz Plugin Jobs",
             "labels": [
-                "grails",
-                "plugin",
-                "schwartz",
-                "schwartz-monitor"
+                "quartz",
+                "scheduling"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/robertoschwald/grails-schwartz-monitor/issues",
+            "issueTrackerUrl": "https://github.com/symentis/grails-schwartz-monitor/issues",
             "latestVersion": "2.0.2",
             "updated": "2019-03-01T11:53:11.524Z",
             "systemIds": [
                 "org.grails.plugins:schwartz-monitor"
             ],
-            "vcsUrl": "https://github.com/robertoschwald/grails-schwartz-monitor"
+            "vcsUrl": "https://github.com/symentis/grails-schwartz-monitor"
         },
-        "documentationUrl": "https://robertoschwald.github.io/grails-schwartz-monitor/",
+        "documentationUrl": "https://symentis.github.io/grails-schwartz-monitor/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/robertoschwald/grails-schwartz-monitor\"><img src=\"https://travis-ci.org/robertoschwald/grails-schwartz-monitor.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<h1>Schwartz Monitor Plugin for Grails</h1>\n<p>This plugin is a fork of the <a href=\"https://grails.org/plugin/quartz-monitor\">quartz-monitor</a> plugin and supports\nthe Grails <a href=\"https://plugins.grails.org/plugin/quartz\">Quartz</a> and Grails <a href=\"https://plugins.grails.org/plugin/schwartz\">Schwartz</a> plugins.</p>\n<p>It allows you to view and administer all your Quartz job services in the web-ui.</p>\n<h2>Prerequisites</h2>\n<p>This plugin requires the <a href=\"http://plugins.grails.org/plugin/grails/quartz\">Grails Quartz</a>\nor <a href=\"http://plugins.grails.org/plugin/agileorbit/schwartz\">Grails Schwartz</a>\nand <a href=\"http://grails.org/plugin/asset-pipeline\">Asset Pipeline</a> plugins to run.</p>\n<h2>Installation</h2>\n<p>Add the plugin to your build.gradle dependencies:</p>\n<pre><code class=\"language-groovy\">dependencies {\n   ...\n   compile &quot;org.grails.plugins:schwartz-monitor:2.0.1&quot;\n}\n</code></pre>\n<h2>Usage</h2>\n<p>Once you have the schwartz-monitor plugin installed and have created some job services, start your application and access the URL:\nhttp://localhost:8080/yourapp/quartz and you will find a list of all the Quartz job services you have created.</p>\n<h2>Enhanced Experience</h2>\n<p>To have the page keep you constantly up to date requires <a href=\"http://grails.org/plugin/jquery\">jQuery</a>. It will still work without jQuery,\nbut it won't look as good.</p>\n<h2>Configuration</h2>\n<p>There are various configuration options, all start with <code>quartz.monitor</code>:</p>\n<h3>layout</h3>\n<p>Allows you to change the sitemesh layout that page will use. Defaults to 'main'.</p>\n<h3>showTriggerNames</h3>\n<p>If this is set to true, then the names of the triggers will be shown in the list - useful if you have multiple triggers for the same job.</p>\n<h3>showCountdown</h3>\n<p>Will add javascript to the page in order to show a countdown to when the job will fire next, unless this is set to 'false'.</p>\n<h3>showTickingClock</h3>\n<p>Will add javascript to the page in order to show a clock with the current time, unless this is set to 'false'.</p>\n<h2>URL Mapping the Controller</h2>\n<p>By default, the plugin does not set an URL-Mapping for the Schwartz Controller. Add a url-mapping to your URLMappings.groovy file:</p>\n<pre><code>&quot;/quartz/$action?&quot;(controller:&quot;quartz&quot;)\n</code></pre>\n<h2>Securing the Controller</h2>\n<p>If you use a security plugin (Spring-Security-Core, etc), you must ensure the controller methods are secured. E.g. when using Spring-Security-Core, add a rule which is appropriate for your security needs:</p>\n<pre><code class=\"language-groovy\">[pattern:'/quartz/**',              access:['ROLE_ADMIN']]\n</code></pre>\n<h2>Documentation</h2>\n<p>http://robertoschwald.github.io/grails-schwartz-monitor</p>\n<h2>Internals</h2>\n<p>Compared to the quartz-monitor plugin, this plugin is agnostic to the used quartz plugin, as it relies on Quartz itself and does not extend\nany quartz-plugin factories.\nIts implemented to register a org.quartz.JobListener, which listens to all Job tasks.\nThis listener updates Job metrics in the QuartzMonitorService, which also provides additional figures like the startTime of a Job.</p>\n"
     },
@@ -5189,21 +5298,23 @@
             "owner": "bertramlabs",
             "desc": "Defines a standard corss-plugin security bridge implementation for better decoupling of authentication in plugin heavy applications.",
             "labels": [
-                
+                "cors",
+                "security"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/grails-security-bridge/issues",
-            "latestVersion": "3.0.0",
-            "updated": "2017-11-07T07:34:50.342Z",
+            "latestVersion": "4.0.0",
+            "updated": "2021-03-31T00:45:04.000Z",
             "systemIds": [
+                "com.bertramlabs.plugins:grails-security-bridge",
                 "com.bertramlabs.plugins:security-bridge"
             ],
             "vcsUrl": "https://github.com/bertramdev/grails-security-bridge"
         },
         "documentationUrl": "https://bertramdev.github.io/grails-security-bridge/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/grails-security-bridge/maven-metadata.xml",
         "readme": "<h1>Grails Security Bridge</h1>\n<p>The Grails Security Bridge plugin is used for providing a decoupled, cross-plugin security interface. This allows you to keep the majority of authentication logic in one plugin, while other plugins can reference a public API interface to retrieve the information needed.</p>\n<h2>Documentation</h2>\n<p>http://bertramdev.github.io/grails-security-bridge</p>\n"
     },
     {
@@ -5213,21 +5324,21 @@
             "owner": "bertramlabs",
             "desc": "Implements a standard convention for adding seed data to your application..",
             "labels": [
-                
+                "seed"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/seed-me/issues",
-            "latestVersion": "4.1.4",
-            "updated": "2021-03-10T22:12:30.686Z",
+            "latestVersion": "5.0.4",
+            "updated": "2022-07-07T13:32:00.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:seed-me"
             ],
             "vcsUrl": "https://github.com/bertramdev/seed-me"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/seed-me/maven-metadata.xml",
         "readme": null
     },
     {
@@ -5237,7 +5348,7 @@
             "owner": "agorapulse",
             "desc": "Grails Segment plugin",
             "labels": [
-                
+                "segment"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5261,21 +5372,22 @@
             "owner": "bertramlabs",
             "desc": "Selfie is a Grails Image / File Upload Plugin. Use Selfie to attach files to your domain models, upload to a CDN, validate content, produce thumbnails.",
             "labels": [
-                
+                "image",
+                "upload"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/selfie/issues",
             "latestVersion": "2.1.4",
-            "updated": "2020-12-07T19:07:47.461Z",
+            "updated": "2021-03-31T01:20:34.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:selfie"
             ],
             "vcsUrl": "https://github.com/bertramdev/selfie"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/selfie/maven-metadata.xml",
         "readme": null
     },
     {
@@ -5285,7 +5397,7 @@
             "owner": "agorapulse",
             "desc": "Grails Sentry plugin",
             "labels": [
-                
+                "sentry"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5309,7 +5421,7 @@
             "owner": "nerderg",
             "desc": "This is a simple, by convention, suggestion service to provide suggestions to auto complete controls.\nJust point the auto complete JS URL at suggest/[subject]?term=bla and you get a JSON list of suggestion strings back.\nYou can add suggestion handlers to the service as a closure, or just add a text file named [subject].txt with an itemper line to be searched for matches. The simple search returns a result if an item string contains the term anywhere.\nSee docs for details.",
             "labels": [
-                
+
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5333,7 +5445,7 @@
             "owner": "mathifonseca",
             "desc": "Grails Slack Integration Plugin",
             "labels": [
-                
+                "slack"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5342,8 +5454,8 @@
             "latestVersion": "3.2.0",
             "updated": "2017-08-20T18:12:02.476Z",
             "systemIds": [
-                "org.grails.plugins:grails-slack",
-                "org.grails.plugins:slack"
+                "org.grails.plugins:slack",
+                "org.grails.plugins:grails-slack"
             ],
             "vcsUrl": "https://github.com/mathifonseca/grails-slack"
         },
@@ -5358,7 +5470,7 @@
             "owner": "danlobo",
             "desc": "Provides Grails domain classes support for soft (or logical) deletes.",
             "labels": [
-                
+                "delete"
             ],
             "licenses": [
                 "MIT"
@@ -5382,7 +5494,9 @@
             "owner": "grails",
             "desc": "Grails spring-security-acl plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "acl"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5406,7 +5520,7 @@
             "owner": "grails",
             "desc": "Grails spring-security-appinfo plugin",
             "labels": [
-                
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5430,14 +5544,16 @@
             "owner": "grails",
             "desc": "The CAS plugin adds CAS single sign-on support to a Grails application that uses Spring Security. It depends on the Spring Security Core plugin.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "cas"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-spring-security-cas/issues",
-            "latestVersion": "3.1.0",
-            "updated": "2017-10-03T11:18:26.828Z",
+            "latestVersion": "4.0.0-RC1",
+            "updated": "2022-03-11T11:12:59.000Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-cas"
             ],
@@ -5454,14 +5570,15 @@
             "owner": "grails",
             "desc": "Grails spring-security-core plugin",
             "labels": [
-                
+                "security",
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-spring-security-core/issues",
             "latestVersion": "5.1.1",
-            "updated": "2021-12-26T05:04:14.000Z",
+            "updated": "2022-11-18T12:38:41.000Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-core"
             ],
@@ -5478,12 +5595,14 @@
             "owner": "splix",
             "desc": "Grails spring-security-facebook plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "facebook"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/spring-security-facebook/issues",
+            "issueTrackerUrl": "https://github.com/splix/grails-spring-security-facebook/issues",
             "latestVersion": "0.19.2",
             "updated": "2017-11-07T07:29:37.704Z",
             "systemIds": [
@@ -5491,7 +5610,7 @@
             ],
             "vcsUrl": "https://github.com/splix/grails-spring-security-facebook"
         },
-        "documentationUrl": null,
+        "documentationUrl": "http://splix.github.io/grails-spring-security-facebook/",
         "mavenMetadataUrl": null,
         "readme": null
     },
@@ -5502,7 +5621,9 @@
             "owner": "budjb",
             "desc": "A plugin that allows the use of Spring Security features with JAX-RS resources.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5515,7 +5636,7 @@
             ],
             "vcsUrl": "https://github.com/budjb/grails-spring-security-jaxrs"
         },
-        "documentationUrl": "https://budjb.github.io/grails-spring-security-jaxrs/",
+        "documentationUrl": "http://budjb.github.io/grails-spring-security-jaxrs/3.x/latest/",
         "mavenMetadataUrl": null,
         "readme": "<p><a href=\"https://travis-ci.org/budjb/grails-spring-security-jaxrs\"><img src=\"https://travis-ci.org/budjb/grails-spring-security-jaxrs.svg?branch=grails-3.x\" alt=\"Build Status\" /></a></p>\n<h2>Spring Security Jaxrs integration plugin for Grails</h2>\n<p>See the documentation at http://budjb.github.io/grails-spring-security-jaxrs/3.x/latest/.</p>\n"
     },
@@ -5526,7 +5647,9 @@
             "owner": "grails",
             "desc": "Grails spring-security-kerberos plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "kerberos"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5550,12 +5673,14 @@
             "owner": "grails",
             "desc": "Grails spring-security-ldap plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "ldap"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "http://jira.grails.org/browse/GPSPRINGSECURITYLDAP",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-ldap/issues",
             "latestVersion": "4.0.0.M1",
             "updated": "2020-03-24T10:30:31.547Z",
             "systemIds": [
@@ -5574,14 +5699,16 @@
             "owner": "grails",
             "desc": "This plugin provides the capability to authenticate via OAuth 2. Depends on Grails spring-security-core.",
             "labels": [
-                
+                "security",
+                "oauth2",
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-spring-security-oauth2/issues",
-            "latestVersion": "1.2.0",
-            "updated": "2018-05-08T18:38:57.737Z",
+            "latestVersion": "2.0.0-RC1",
+            "updated": "2022-03-22T07:47:44.000Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-oauth2"
             ],
@@ -5592,13 +5719,16 @@
         "readme": null
     },
     {
+        "deprecated": "Stale duplicate of the entry with the same name by author 'grails'. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "spring-security-oauth2",
             "repo": "plugins",
             "owner": "matrixcrawler",
             "desc": "This plugin provides the capability to authenticate via oauth. Depends on grails-spring-security-core.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5622,7 +5752,9 @@
             "owner": "matrixcrawler",
             "desc": "This plugin provides the capability to authenticate via facebook-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5646,7 +5778,9 @@
             "owner": "rpalcolea",
             "desc": "This plugin provides the capability to authenticate via Github-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5664,13 +5798,16 @@
         "readme": "<h1>Spring Security OAuth2 Github Plugin</h1>\n<p><a href=\"https://travis-ci.org/rpalcolea/grails-spring-security-oauth2-github\"><img src=\"https://travis-ci.org/rpalcolea/grails-spring-security-oauth2-github.svg?branch=master\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/rpalcolea/plugins/spring-security-oauth2-github/_latestVersion\"><img src=\"https://api.bintray.com/packages/rpalcolea/plugins/spring-security-oauth2-github/images/download.svg\" alt=\"Download\" /></a>\n<a href=\"http://slack-signup.grails.org\"><img src=\"http://slack-signup.grails.org/badge.svg\" alt=\"Slack Signup\" /></a></p>\n<p>Add a Github OAuth2 provider to the <a href=\"https://github.com/MatrixCrawler/grails-spring-security-oauth2\">Spring Security OAuth2 Plugin</a> by @MatrixCrawler (Johannes Brunswicker).</p>\n<h2>Installation</h2>\n<p>Add the following dependencies in <code>build.gradle</code></p>\n<pre><code>dependencies {\n...\n    compile 'org.grails.plugins:spring-security-oauth2:1.+'\n    compile 'org.grails.plugins:spring-security-oauth2-github:1.0.+'\n...\n}\n</code></pre>\n<h2>Usage</h2>\n<p>Add this to your application.yml</p>\n<pre><code>grails:\n    plugin:\n        springsecurity:\n            oauth2:\n                providers:\n                    github:\n                        api_key: 'github-client-id'             #needed\n                        api_secret: 'github-client-secret'      #needed\n                        successUri: &quot;/oauth2/github/success&quot;    #optional\n                        failureUri: &quot;/oauth2/github/failure&quot;    #optional\n                        callback: &quot;/oauth2/github/callback&quot;     #optional\n</code></pre>\n<p>You can replace the URIs with your own controller implementation.</p>\n<p>In your view you can use the taglib exposed from this plugin and from OAuth plugin to create links and to know if the user is authenticated with a given provider:</p>\n<pre><code class=\"language-xml\">&lt;oauth2:connect provider=&quot;github&quot; id=&quot;github-connect-link&quot;&gt;Github&lt;/oauth2:connect&gt;\n\nLogged with Github?\n&lt;oauth2:ifLoggedInWith provider=&quot;github&quot;&gt;yes&lt;/oauth2:ifLoggedInWith&gt;\n&lt;oauth2:ifNotLoggedInWith provider=&quot;github&quot;&gt;no&lt;/oauth2:ifNotLoggedInWith&gt;\n</code></pre>\n<h2>License</h2>\n<p>Apache 2</p>\n<h2>Sponsors</h2>\n<p><a href=\"https://www.yourkit.com/.net/profiler/index.jsp\"><img src=\"https://www.yourkit.com/images/yklogo.png\" alt=\"Alt text\" title=\"YourKit\" /></a></p>\n<p>YourKit supports open source projects with its full-featured Java Profiler.\nYourKit, LLC is the creator of <a href=\"https://www.yourkit.com/java/profiler/index.jsp\">YourKit Java Profiler</a>\nand <a href=\"https://www.yourkit.com/.net/profiler/index.jsp\">YourKit .NET Profiler</a>,\ninnovative and intelligent tools for profiling Java and .NET applications.</p>\n"
     },
     {
+        "deprecated": "This plugin seems superseeded by the plugin with the same name by author grails. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "spring-security-oauth2-google",
             "repo": "plugins",
             "owner": "matrixcrawler",
             "desc": "This plugin provides the capability to authenticate via g+-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5694,7 +5831,9 @@
             "owner": "grails",
             "desc": "This plugin provides the capability to authenticate via g+-oauth provider. Depends on grails-spring-security-oauth2. v1.2.0 starts after fork to grails-plugins org. Includes unreleased 1.1.1 from other repo.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5718,7 +5857,9 @@
             "owner": "purpleraven",
             "desc": "This plugin provides the capability to authenticate via ok-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5742,7 +5883,9 @@
             "owner": "andreperegrina",
             "desc": "This plugin provides the capability to authenticate via outlook-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5763,23 +5906,25 @@
         "bintrayPackage": {
             "name": "spring-security-oauth2-provider",
             "repo": "grails-plugins",
-            "owner": "bluesliverx",
+            "owner": "grails",
             "desc": "Grails OAuth 2 Provider Plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/bluesliverx/grails-spring-security-oauth2-provider/issues",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-oauth2-provider/issues",
             "latestVersion": "4.0.0-RC1",
             "updated": "2019-07-19T14:51:49.069Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-oauth2-provider"
             ],
-            "vcsUrl": "https://github.com/bluesliverx/grails-spring-security-oauth2-provider"
+            "vcsUrl": "https://github.com/grails-plugins/grails-spring-security-oauth2-provider"
         },
-        "documentationUrl": "https://bluesliverx.github.io/grails-spring-security-oauth2-provider/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-oauth2-provider/",
         "mavenMetadataUrl": null,
         "readme": "<h2>Deprecation Notice</h2>\n<p>The plugin has been moved to new repository.</p>\n<p>Please browse to <a href=\"https://github.com/grails-plugins\">grails-plugins</a> fork for new updates for the plugin source code:\nhttps://github.com/grails-plugins/grails-spring-security-oauth2-provider</p>\n<h1>Grails Spring Security OAuth2 Provider Plugin</h1>\n<p><a href=\"https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider\"><img src=\"https://travis-ci.org/bluesliverx/grails-spring-security-oauth2-provider.svg?branch=master\" alt=\"Build Status\" /></a></p>\n<p>See <a href=\"http://bluesliverx.github.io/grails-spring-security-oauth2-provider/\">documentation</a> and the\n<a href=\"http://plugins.grails.org/plugin/bluesliverx/spring-security-oauth2-provider\">Grails plugin page</a> for further information.</p>\n<p>Until the newer deploys work with the Grails repos, you may use the following for Grails 3.3+:</p>\n<pre><code>repositories {\n  ...\n  maven { url &quot;http://dl.bintray.com/bluesliverx/grails-plugins&quot; }\n}\ndependencies {\n  ...\n  compile 'org.grails.plugins:spring-security-oauth2-provider:3.1.0-RC1'\n}\n</code></pre>\n"
     },
@@ -5790,7 +5935,9 @@
             "owner": "purpleraven",
             "desc": "This plugin provides the capability to authenticate via vk-oauth provider. Depends on grails-spring-security-oauth2.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "oauth2"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5814,12 +5961,14 @@
             "owner": "grails",
             "desc": "Grails spring-security-rest plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "spring-security-rest"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/alvarosanchez/grails-spring-security-rest/issues",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-rest/issues",
             "latestVersion": "3.0.1",
             "updated": "2020-04-06T05:51:10.703Z",
             "systemIds": [
@@ -5827,7 +5976,7 @@
             ],
             "vcsUrl": "https://github.com/alvarosanchez/grails-spring-security-rest"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/latest/docs/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Spring Security REST for Grails</h1>\n<p><a href=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest\"><img src=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest.png?branch=develop\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/grails/plugins/spring-security-rest/_latestVersion\"><img src=\"https://api.bintray.com/packages/grails/plugins/spring-security-rest/images/download.svg\" alt=\"Latest version\" /></a>\n<a href=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest\"><img src=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest/develop/badge.svg\" alt=\"Known Vulnerabilities\" /></a></p>\n<p>Grails plugin to implement a stateless, token-based, RESTful authentication\nusing Spring Security. Sponsored and supported by <a href=\"http://www.ociweb.com\">Object Computing Inc.</a></p>\n<p>Documentation:</p>\n<ul>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/\">User guide</a>.</li>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/\">Javadoc</a>.</li>\n</ul>\n<h2>Companies using this plugin</h2>\n<ul>\n<li><a href=\"http://www.onlinephotosubmission.com\">CloudCard Online Photo Submission</a></li>\n<li><a href=\"http://www.healthreveal.com\">HealthReveal</a></li>\n<li><a href=\"http://murallo.com\">Murallo</a></li>\n<li><a href=\"http://www.odobo.com\">Odobo</a></li>\n<li><a href=\"http://www.sharptop.io\">Sharptop Software</a></li>\n<li><a href=\"http://www.zaccak.com\">Zaccak Solutions</a></li>\n<li><a href=\"https://lyshnia.com\">Lyshnia Limited</a></li>\n<li><a href=\"https://www.wizpanda.com\">Wiz Panda</a></li>\n<li><a href=\"https://zana.com\">Zana Technologies GmbH</a></li>\n</ul>\n<p><em>Are you using this plugin and want to be listed here? <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/edit/develop/README.md\">Include your company yourself</a></em>.</p>\n<h2>Support</h2>\n<ul>\n<li>General questions should go to the <a href=\"https://grails.slack.com/messages/spring-security-rest\"><code>#spring-security-rest</code> channel in Slack</a>.</li>\n<li>You can also find answers at <a href=\"http://stackoverflow.com/questions/tagged/grails+spring-security-rest\">StackOverflow</a>. Label your questions with both the <code>grails</code> and <code>spring-security-rest</code> tags.</li>\n<li>If you've got issues, report them <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/issues\">here in GitHub</a>.</li>\n<li>If you need commercial support, you can ask <a href=\"http://www.ociweb.com\">OCI</a> at <a href=\"mailto:infoATociwebDOTcom\">info AT ociweb DOT com</a>.</li>\n</ul>\n<p><strong>NOTE</strong>: if you have questions or issues, <a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/index.html#_debugging\">enable debug logging</a>,\nand include the output in your request.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/aeischeid\">Aaron Eischeid</a>.</li>\n<li><a href=\"https://github.com/ajbrown\">A.J. Brown</a>.</li>\n<li><a href=\"https://github.com/andrew-wharton\">Andrew Wharton</a>.</li>\n<li><a href=\"https://github.com/andrehschmid\">Andr\ufffd\ufffd\ufffd\ufffd Schmid</a>.</li>\n<li><a href=\"https://github.com/Alotor\">Alonso Torres</a>.</li>\n<li><a href=\"https://github.com/bgawel\">Bartek Gawel</a>.</li>\n<li><a href=\"https://github.com/rbfinch\">Bob Finch</a>.</li>\n<li><a href=\"https://github.com/bobbywarner\">Bobby Warner</a>.</li>\n<li><a href=\"https://github.com/burtbeckwith\">Burt Beckwith</a>.</li>\n<li><a href=\"https://github.com/conalllaverty\">Conall Laverty</a>.</li>\n<li><a href=\"https://github.com/tkvw\">Dennie de Lange</a>.</li>\n<li><a href=\"https://github.com/dmahapatro\">Dhiraj Mahapatro</a>.</li>\n<li><a href=\"https://github.com/domurtag\">Donal Murtagh</a>.</li>\n<li><a href=\"https://github.com/liftyourgame\">Greg Pagendam-Turner</a>.</li>\n<li><a href=\"https://github.com/Schlogen\">James Kleeh</a>.</li>\n<li><a href=\"https://github.com/jladenfors\">Jonas Ladenfors</a>.</li>\n<li><a href=\"https://github.com/jagedn\">Jorge Aguilera</a>.</li>\n<li><a href=\"https://github.com/zeludo\">Ludovic Ronsin</a>.</li>\n<li><a href=\"https://github.com/stlhrt\">Lukasz Wozniak</a>.</li>\n<li><a href=\"https://github.com/marcos-carceles\">Marcos Carceles</a>.</li>\n<li><a href=\"https://github.com/michallula\">Micha\ufffd\ufffd\ufffd\ufffd\ufffd Lula</a>.</li>\n<li><a href=\"https://github.com/majkelo\">Michal Szulc</a>.</li>\n<li><a href=\"https://github.com/nllarson\">Nick Larson</a>.</li>\n<li><a href=\"https://github.com/peh\">Philipp Eschenbach</a>.</li>\n<li><a href=\"https://github.com/giboow\">Philippe Gibert</a>.</li>\n<li><a href=\"https://github.com/pphetra\">Polawat Phetra</a>.</li>\n<li><a href=\"https://github.com/rvargas\">Rafael Vargas</a>.</li>\n<li><a href=\"https://github.com/sbrady\">Sean Brady</a>.</li>\n<li><a href=\"https://github.com/Prototik\">Sergey Shatunov</a>.</li>\n<li><a href=\"https://github.com/sdelamo\">Sergio del Amo</a>.</li>\n<li><a href=\"https://github.com/sagrawal31\">Shashank Agrawal</a>.</li>\n<li><a href=\"https://github.com/srohlin\">Svante Rohlin</a>.</li>\n<li><a href=\"https://github.com/tcrespog\">Tom\ufffd\ufffd\ufffd\ufffds Crespo</a>.</li>\n<li><a href=\"https://github.com/tonyerskine\">Tony Erskine</a>.</li>\n<li><a href=\"https://github.com/vsaar\">Victor Saar</a>.</li>\n</ul>\n<h2>License</h2>\n<p>This software is licensed under the terms of the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0</a></p>\n"
     },
@@ -5838,20 +5987,22 @@
             "owner": "grails",
             "desc": "Spring Security REST plugin for Grails - GORM module",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "spring-security-rest"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-rest/issues",
             "latestVersion": "3.0.1",
             "updated": "2020-04-06T05:51:13.612Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-rest-gorm"
             ],
-            "vcsUrl": "https://github.com/alvarosanchez/grails-spring-security-rest"
+            "vcsUrl": "https://github.com/grails-plugins/grails-spring-security-rest"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/latest/docs/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Spring Security REST for Grails</h1>\n<p><a href=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest\"><img src=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest.png?branch=develop\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/grails/plugins/spring-security-rest/_latestVersion\"><img src=\"https://api.bintray.com/packages/grails/plugins/spring-security-rest/images/download.svg\" alt=\"Latest version\" /></a>\n<a href=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest\"><img src=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest/develop/badge.svg\" alt=\"Known Vulnerabilities\" /></a></p>\n<p>Grails plugin to implement a stateless, token-based, RESTful authentication\nusing Spring Security. Sponsored and supported by <a href=\"http://www.ociweb.com\">Object Computing Inc.</a></p>\n<p>Documentation:</p>\n<ul>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/\">User guide</a>.</li>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/\">Javadoc</a>.</li>\n</ul>\n<h2>Companies using this plugin</h2>\n<ul>\n<li><a href=\"http://www.onlinephotosubmission.com\">CloudCard Online Photo Submission</a></li>\n<li><a href=\"http://www.healthreveal.com\">HealthReveal</a></li>\n<li><a href=\"http://murallo.com\">Murallo</a></li>\n<li><a href=\"http://www.odobo.com\">Odobo</a></li>\n<li><a href=\"http://www.sharptop.io\">Sharptop Software</a></li>\n<li><a href=\"http://www.zaccak.com\">Zaccak Solutions</a></li>\n<li><a href=\"https://lyshnia.com\">Lyshnia Limited</a></li>\n<li><a href=\"https://www.wizpanda.com\">Wiz Panda</a></li>\n<li><a href=\"https://zana.com\">Zana Technologies GmbH</a></li>\n</ul>\n<p><em>Are you using this plugin and want to be listed here? <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/edit/develop/README.md\">Include your company yourself</a></em>.</p>\n<h2>Support</h2>\n<ul>\n<li>General questions should go to the <a href=\"https://grails.slack.com/messages/spring-security-rest\"><code>#spring-security-rest</code> channel in Slack</a>.</li>\n<li>You can also find answers at <a href=\"http://stackoverflow.com/questions/tagged/grails+spring-security-rest\">StackOverflow</a>. Label your questions with both the <code>grails</code> and <code>spring-security-rest</code> tags.</li>\n<li>If you've got issues, report them <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/issues\">here in GitHub</a>.</li>\n<li>If you need commercial support, you can ask <a href=\"http://www.ociweb.com\">OCI</a> at <a href=\"mailto:infoATociwebDOTcom\">info AT ociweb DOT com</a>.</li>\n</ul>\n<p><strong>NOTE</strong>: if you have questions or issues, <a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/index.html#_debugging\">enable debug logging</a>,\nand include the output in your request.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/aeischeid\">Aaron Eischeid</a>.</li>\n<li><a href=\"https://github.com/ajbrown\">A.J. Brown</a>.</li>\n<li><a href=\"https://github.com/andrew-wharton\">Andrew Wharton</a>.</li>\n<li><a href=\"https://github.com/andrehschmid\">Andr\ufffd\ufffd\ufffd\ufffd Schmid</a>.</li>\n<li><a href=\"https://github.com/Alotor\">Alonso Torres</a>.</li>\n<li><a href=\"https://github.com/bgawel\">Bartek Gawel</a>.</li>\n<li><a href=\"https://github.com/rbfinch\">Bob Finch</a>.</li>\n<li><a href=\"https://github.com/bobbywarner\">Bobby Warner</a>.</li>\n<li><a href=\"https://github.com/burtbeckwith\">Burt Beckwith</a>.</li>\n<li><a href=\"https://github.com/conalllaverty\">Conall Laverty</a>.</li>\n<li><a href=\"https://github.com/tkvw\">Dennie de Lange</a>.</li>\n<li><a href=\"https://github.com/dmahapatro\">Dhiraj Mahapatro</a>.</li>\n<li><a href=\"https://github.com/domurtag\">Donal Murtagh</a>.</li>\n<li><a href=\"https://github.com/liftyourgame\">Greg Pagendam-Turner</a>.</li>\n<li><a href=\"https://github.com/Schlogen\">James Kleeh</a>.</li>\n<li><a href=\"https://github.com/jladenfors\">Jonas Ladenfors</a>.</li>\n<li><a href=\"https://github.com/jagedn\">Jorge Aguilera</a>.</li>\n<li><a href=\"https://github.com/zeludo\">Ludovic Ronsin</a>.</li>\n<li><a href=\"https://github.com/stlhrt\">Lukasz Wozniak</a>.</li>\n<li><a href=\"https://github.com/marcos-carceles\">Marcos Carceles</a>.</li>\n<li><a href=\"https://github.com/michallula\">Micha\ufffd\ufffd\ufffd\ufffd\ufffd Lula</a>.</li>\n<li><a href=\"https://github.com/majkelo\">Michal Szulc</a>.</li>\n<li><a href=\"https://github.com/nllarson\">Nick Larson</a>.</li>\n<li><a href=\"https://github.com/peh\">Philipp Eschenbach</a>.</li>\n<li><a href=\"https://github.com/giboow\">Philippe Gibert</a>.</li>\n<li><a href=\"https://github.com/pphetra\">Polawat Phetra</a>.</li>\n<li><a href=\"https://github.com/rvargas\">Rafael Vargas</a>.</li>\n<li><a href=\"https://github.com/sbrady\">Sean Brady</a>.</li>\n<li><a href=\"https://github.com/Prototik\">Sergey Shatunov</a>.</li>\n<li><a href=\"https://github.com/sdelamo\">Sergio del Amo</a>.</li>\n<li><a href=\"https://github.com/sagrawal31\">Shashank Agrawal</a>.</li>\n<li><a href=\"https://github.com/srohlin\">Svante Rohlin</a>.</li>\n<li><a href=\"https://github.com/tcrespog\">Tom\ufffd\ufffd\ufffd\ufffds Crespo</a>.</li>\n<li><a href=\"https://github.com/tonyerskine\">Tony Erskine</a>.</li>\n<li><a href=\"https://github.com/vsaar\">Victor Saar</a>.</li>\n</ul>\n<h2>License</h2>\n<p>This software is licensed under the terms of the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0</a></p>\n"
     },
@@ -5862,20 +6013,22 @@
             "owner": "grails",
             "desc": "Spring Security REST plugin for Grails - Grails cache module",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "spring-security-rest"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-rest/issues",
             "latestVersion": "3.0.1",
             "updated": "2020-04-06T05:51:20.871Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-rest-grailscache"
             ],
-            "vcsUrl": "https://github.com/alvarosanchez/grails-spring-security-rest"
+            "vcsUrl": "https://github.com/grails-plugins/grails-spring-security-rest"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/latest/docs/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Spring Security REST for Grails</h1>\n<p><a href=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest\"><img src=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest.png?branch=develop\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/grails/plugins/spring-security-rest/_latestVersion\"><img src=\"https://api.bintray.com/packages/grails/plugins/spring-security-rest/images/download.svg\" alt=\"Latest version\" /></a>\n<a href=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest\"><img src=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest/develop/badge.svg\" alt=\"Known Vulnerabilities\" /></a></p>\n<p>Grails plugin to implement a stateless, token-based, RESTful authentication\nusing Spring Security. Sponsored and supported by <a href=\"http://www.ociweb.com\">Object Computing Inc.</a></p>\n<p>Documentation:</p>\n<ul>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/\">User guide</a>.</li>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/\">Javadoc</a>.</li>\n</ul>\n<h2>Companies using this plugin</h2>\n<ul>\n<li><a href=\"http://www.onlinephotosubmission.com\">CloudCard Online Photo Submission</a></li>\n<li><a href=\"http://www.healthreveal.com\">HealthReveal</a></li>\n<li><a href=\"http://murallo.com\">Murallo</a></li>\n<li><a href=\"http://www.odobo.com\">Odobo</a></li>\n<li><a href=\"http://www.sharptop.io\">Sharptop Software</a></li>\n<li><a href=\"http://www.zaccak.com\">Zaccak Solutions</a></li>\n<li><a href=\"https://lyshnia.com\">Lyshnia Limited</a></li>\n<li><a href=\"https://www.wizpanda.com\">Wiz Panda</a></li>\n<li><a href=\"https://zana.com\">Zana Technologies GmbH</a></li>\n</ul>\n<p><em>Are you using this plugin and want to be listed here? <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/edit/develop/README.md\">Include your company yourself</a></em>.</p>\n<h2>Support</h2>\n<ul>\n<li>General questions should go to the <a href=\"https://grails.slack.com/messages/spring-security-rest\"><code>#spring-security-rest</code> channel in Slack</a>.</li>\n<li>You can also find answers at <a href=\"http://stackoverflow.com/questions/tagged/grails+spring-security-rest\">StackOverflow</a>. Label your questions with both the <code>grails</code> and <code>spring-security-rest</code> tags.</li>\n<li>If you've got issues, report them <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/issues\">here in GitHub</a>.</li>\n<li>If you need commercial support, you can ask <a href=\"http://www.ociweb.com\">OCI</a> at <a href=\"mailto:infoATociwebDOTcom\">info AT ociweb DOT com</a>.</li>\n</ul>\n<p><strong>NOTE</strong>: if you have questions or issues, <a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/index.html#_debugging\">enable debug logging</a>,\nand include the output in your request.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/aeischeid\">Aaron Eischeid</a>.</li>\n<li><a href=\"https://github.com/ajbrown\">A.J. Brown</a>.</li>\n<li><a href=\"https://github.com/andrew-wharton\">Andrew Wharton</a>.</li>\n<li><a href=\"https://github.com/andrehschmid\">Andr\ufffd\ufffd\ufffd\ufffd Schmid</a>.</li>\n<li><a href=\"https://github.com/Alotor\">Alonso Torres</a>.</li>\n<li><a href=\"https://github.com/bgawel\">Bartek Gawel</a>.</li>\n<li><a href=\"https://github.com/rbfinch\">Bob Finch</a>.</li>\n<li><a href=\"https://github.com/bobbywarner\">Bobby Warner</a>.</li>\n<li><a href=\"https://github.com/burtbeckwith\">Burt Beckwith</a>.</li>\n<li><a href=\"https://github.com/conalllaverty\">Conall Laverty</a>.</li>\n<li><a href=\"https://github.com/tkvw\">Dennie de Lange</a>.</li>\n<li><a href=\"https://github.com/dmahapatro\">Dhiraj Mahapatro</a>.</li>\n<li><a href=\"https://github.com/domurtag\">Donal Murtagh</a>.</li>\n<li><a href=\"https://github.com/liftyourgame\">Greg Pagendam-Turner</a>.</li>\n<li><a href=\"https://github.com/Schlogen\">James Kleeh</a>.</li>\n<li><a href=\"https://github.com/jladenfors\">Jonas Ladenfors</a>.</li>\n<li><a href=\"https://github.com/jagedn\">Jorge Aguilera</a>.</li>\n<li><a href=\"https://github.com/zeludo\">Ludovic Ronsin</a>.</li>\n<li><a href=\"https://github.com/stlhrt\">Lukasz Wozniak</a>.</li>\n<li><a href=\"https://github.com/marcos-carceles\">Marcos Carceles</a>.</li>\n<li><a href=\"https://github.com/michallula\">Micha\ufffd\ufffd\ufffd\ufffd\ufffd Lula</a>.</li>\n<li><a href=\"https://github.com/majkelo\">Michal Szulc</a>.</li>\n<li><a href=\"https://github.com/nllarson\">Nick Larson</a>.</li>\n<li><a href=\"https://github.com/peh\">Philipp Eschenbach</a>.</li>\n<li><a href=\"https://github.com/giboow\">Philippe Gibert</a>.</li>\n<li><a href=\"https://github.com/pphetra\">Polawat Phetra</a>.</li>\n<li><a href=\"https://github.com/rvargas\">Rafael Vargas</a>.</li>\n<li><a href=\"https://github.com/sbrady\">Sean Brady</a>.</li>\n<li><a href=\"https://github.com/Prototik\">Sergey Shatunov</a>.</li>\n<li><a href=\"https://github.com/sdelamo\">Sergio del Amo</a>.</li>\n<li><a href=\"https://github.com/sagrawal31\">Shashank Agrawal</a>.</li>\n<li><a href=\"https://github.com/srohlin\">Svante Rohlin</a>.</li>\n<li><a href=\"https://github.com/tcrespog\">Tom\ufffd\ufffd\ufffd\ufffds Crespo</a>.</li>\n<li><a href=\"https://github.com/tonyerskine\">Tony Erskine</a>.</li>\n<li><a href=\"https://github.com/vsaar\">Victor Saar</a>.</li>\n</ul>\n<h2>License</h2>\n<p>This software is licensed under the terms of the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0</a></p>\n"
     },
@@ -5886,20 +6039,23 @@
             "owner": "grails",
             "desc": "Grails plugin to implement token-based, RESTful authentication using Spring Security",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "spring-security-rest",
+                "memcached"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/alvarosanchez/grails-spring-security-rest/issues",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-rest/issues",
             "latestVersion": "3.0.1",
             "updated": "2020-04-06T05:51:16.025Z",
             "systemIds": [
                 "org.grails.plugins:spring-security-rest-memcached"
             ],
-            "vcsUrl": "https://github.com/alvarosanchez/grails-spring-security-rest"
+            "vcsUrl": "https://github.com/grails-plugins/grails-spring-security-rest"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/latest/docs/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Spring Security REST for Grails</h1>\n<p><a href=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest\"><img src=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest.png?branch=develop\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/grails/plugins/spring-security-rest/_latestVersion\"><img src=\"https://api.bintray.com/packages/grails/plugins/spring-security-rest/images/download.svg\" alt=\"Latest version\" /></a>\n<a href=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest\"><img src=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest/develop/badge.svg\" alt=\"Known Vulnerabilities\" /></a></p>\n<p>Grails plugin to implement a stateless, token-based, RESTful authentication\nusing Spring Security. Sponsored and supported by <a href=\"http://www.ociweb.com\">Object Computing Inc.</a></p>\n<p>Documentation:</p>\n<ul>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/\">User guide</a>.</li>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/\">Javadoc</a>.</li>\n</ul>\n<h2>Companies using this plugin</h2>\n<ul>\n<li><a href=\"http://www.onlinephotosubmission.com\">CloudCard Online Photo Submission</a></li>\n<li><a href=\"http://www.healthreveal.com\">HealthReveal</a></li>\n<li><a href=\"http://murallo.com\">Murallo</a></li>\n<li><a href=\"http://www.odobo.com\">Odobo</a></li>\n<li><a href=\"http://www.sharptop.io\">Sharptop Software</a></li>\n<li><a href=\"http://www.zaccak.com\">Zaccak Solutions</a></li>\n<li><a href=\"https://lyshnia.com\">Lyshnia Limited</a></li>\n<li><a href=\"https://www.wizpanda.com\">Wiz Panda</a></li>\n<li><a href=\"https://zana.com\">Zana Technologies GmbH</a></li>\n</ul>\n<p><em>Are you using this plugin and want to be listed here? <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/edit/develop/README.md\">Include your company yourself</a></em>.</p>\n<h2>Support</h2>\n<ul>\n<li>General questions should go to the <a href=\"https://grails.slack.com/messages/spring-security-rest\"><code>#spring-security-rest</code> channel in Slack</a>.</li>\n<li>You can also find answers at <a href=\"http://stackoverflow.com/questions/tagged/grails+spring-security-rest\">StackOverflow</a>. Label your questions with both the <code>grails</code> and <code>spring-security-rest</code> tags.</li>\n<li>If you've got issues, report them <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/issues\">here in GitHub</a>.</li>\n<li>If you need commercial support, you can ask <a href=\"http://www.ociweb.com\">OCI</a> at <a href=\"mailto:infoATociwebDOTcom\">info AT ociweb DOT com</a>.</li>\n</ul>\n<p><strong>NOTE</strong>: if you have questions or issues, <a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/index.html#_debugging\">enable debug logging</a>,\nand include the output in your request.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/aeischeid\">Aaron Eischeid</a>.</li>\n<li><a href=\"https://github.com/ajbrown\">A.J. Brown</a>.</li>\n<li><a href=\"https://github.com/andrew-wharton\">Andrew Wharton</a>.</li>\n<li><a href=\"https://github.com/andrehschmid\">Andr\ufffd\ufffd\ufffd\ufffd Schmid</a>.</li>\n<li><a href=\"https://github.com/Alotor\">Alonso Torres</a>.</li>\n<li><a href=\"https://github.com/bgawel\">Bartek Gawel</a>.</li>\n<li><a href=\"https://github.com/rbfinch\">Bob Finch</a>.</li>\n<li><a href=\"https://github.com/bobbywarner\">Bobby Warner</a>.</li>\n<li><a href=\"https://github.com/burtbeckwith\">Burt Beckwith</a>.</li>\n<li><a href=\"https://github.com/conalllaverty\">Conall Laverty</a>.</li>\n<li><a href=\"https://github.com/tkvw\">Dennie de Lange</a>.</li>\n<li><a href=\"https://github.com/dmahapatro\">Dhiraj Mahapatro</a>.</li>\n<li><a href=\"https://github.com/domurtag\">Donal Murtagh</a>.</li>\n<li><a href=\"https://github.com/liftyourgame\">Greg Pagendam-Turner</a>.</li>\n<li><a href=\"https://github.com/Schlogen\">James Kleeh</a>.</li>\n<li><a href=\"https://github.com/jladenfors\">Jonas Ladenfors</a>.</li>\n<li><a href=\"https://github.com/jagedn\">Jorge Aguilera</a>.</li>\n<li><a href=\"https://github.com/zeludo\">Ludovic Ronsin</a>.</li>\n<li><a href=\"https://github.com/stlhrt\">Lukasz Wozniak</a>.</li>\n<li><a href=\"https://github.com/marcos-carceles\">Marcos Carceles</a>.</li>\n<li><a href=\"https://github.com/michallula\">Micha\ufffd\ufffd\ufffd\ufffd\ufffd Lula</a>.</li>\n<li><a href=\"https://github.com/majkelo\">Michal Szulc</a>.</li>\n<li><a href=\"https://github.com/nllarson\">Nick Larson</a>.</li>\n<li><a href=\"https://github.com/peh\">Philipp Eschenbach</a>.</li>\n<li><a href=\"https://github.com/giboow\">Philippe Gibert</a>.</li>\n<li><a href=\"https://github.com/pphetra\">Polawat Phetra</a>.</li>\n<li><a href=\"https://github.com/rvargas\">Rafael Vargas</a>.</li>\n<li><a href=\"https://github.com/sbrady\">Sean Brady</a>.</li>\n<li><a href=\"https://github.com/Prototik\">Sergey Shatunov</a>.</li>\n<li><a href=\"https://github.com/sdelamo\">Sergio del Amo</a>.</li>\n<li><a href=\"https://github.com/sagrawal31\">Shashank Agrawal</a>.</li>\n<li><a href=\"https://github.com/srohlin\">Svante Rohlin</a>.</li>\n<li><a href=\"https://github.com/tcrespog\">Tom\ufffd\ufffd\ufffd\ufffds Crespo</a>.</li>\n<li><a href=\"https://github.com/tonyerskine\">Tony Erskine</a>.</li>\n<li><a href=\"https://github.com/vsaar\">Victor Saar</a>.</li>\n</ul>\n<h2>License</h2>\n<p>This software is licensed under the terms of the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0</a></p>\n"
     },
@@ -5910,12 +6066,15 @@
             "owner": "grails",
             "desc": "Spring Security REST plugin for Grails - Redis module",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "spring-security-rest",
+                "redis"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "",
+            "issueTrackerUrl": "https://github.com/grails-plugins/grails-spring-security-rest/issues",
             "latestVersion": "3.0.1",
             "updated": "2020-04-06T05:51:18.295Z",
             "systemIds": [
@@ -5923,18 +6082,21 @@
             ],
             "vcsUrl": "https://github.com/alvarosanchez/grails-spring-security-rest"
         },
-        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/",
+        "documentationUrl": "https://grails-plugins.github.io/grails-spring-security-rest/latest/docs/",
         "mavenMetadataUrl": null,
         "readme": "<h1>Spring Security REST for Grails</h1>\n<p><a href=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest\"><img src=\"https://travis-ci.org/alvarosanchez/grails-spring-security-rest.png?branch=develop\" alt=\"Build Status\" /></a>\n<a href=\"https://bintray.com/grails/plugins/spring-security-rest/_latestVersion\"><img src=\"https://api.bintray.com/packages/grails/plugins/spring-security-rest/images/download.svg\" alt=\"Latest version\" /></a>\n<a href=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest\"><img src=\"https://snyk.io/test/github/alvarosanchez/grails-spring-security-rest/develop/badge.svg\" alt=\"Known Vulnerabilities\" /></a></p>\n<p>Grails plugin to implement a stateless, token-based, RESTful authentication\nusing Spring Security. Sponsored and supported by <a href=\"http://www.ociweb.com\">Object Computing Inc.</a></p>\n<p>Documentation:</p>\n<ul>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/\">User guide</a>.</li>\n<li><a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/gapi/\">Javadoc</a>.</li>\n</ul>\n<h2>Companies using this plugin</h2>\n<ul>\n<li><a href=\"http://www.onlinephotosubmission.com\">CloudCard Online Photo Submission</a></li>\n<li><a href=\"http://www.healthreveal.com\">HealthReveal</a></li>\n<li><a href=\"http://murallo.com\">Murallo</a></li>\n<li><a href=\"http://www.odobo.com\">Odobo</a></li>\n<li><a href=\"http://www.sharptop.io\">Sharptop Software</a></li>\n<li><a href=\"http://www.zaccak.com\">Zaccak Solutions</a></li>\n<li><a href=\"https://lyshnia.com\">Lyshnia Limited</a></li>\n<li><a href=\"https://www.wizpanda.com\">Wiz Panda</a></li>\n<li><a href=\"https://zana.com\">Zana Technologies GmbH</a></li>\n</ul>\n<p><em>Are you using this plugin and want to be listed here? <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/edit/develop/README.md\">Include your company yourself</a></em>.</p>\n<h2>Support</h2>\n<ul>\n<li>General questions should go to the <a href=\"https://grails.slack.com/messages/spring-security-rest\"><code>#spring-security-rest</code> channel in Slack</a>.</li>\n<li>You can also find answers at <a href=\"http://stackoverflow.com/questions/tagged/grails+spring-security-rest\">StackOverflow</a>. Label your questions with both the <code>grails</code> and <code>spring-security-rest</code> tags.</li>\n<li>If you've got issues, report them <a href=\"https://github.com/alvarosanchez/grails-spring-security-rest/issues\">here in GitHub</a>.</li>\n<li>If you need commercial support, you can ask <a href=\"http://www.ociweb.com\">OCI</a> at <a href=\"mailto:infoATociwebDOTcom\">info AT ociweb DOT com</a>.</li>\n</ul>\n<p><strong>NOTE</strong>: if you have questions or issues, <a href=\"http://alvarosanchez.github.io/grails-spring-security-rest/latest/docs/index.html#_debugging\">enable debug logging</a>,\nand include the output in your request.</p>\n<h2>Contributors</h2>\n<ul>\n<li><a href=\"https://github.com/aeischeid\">Aaron Eischeid</a>.</li>\n<li><a href=\"https://github.com/ajbrown\">A.J. Brown</a>.</li>\n<li><a href=\"https://github.com/andrew-wharton\">Andrew Wharton</a>.</li>\n<li><a href=\"https://github.com/andrehschmid\">Andr\ufffd\ufffd\ufffd\ufffd Schmid</a>.</li>\n<li><a href=\"https://github.com/Alotor\">Alonso Torres</a>.</li>\n<li><a href=\"https://github.com/bgawel\">Bartek Gawel</a>.</li>\n<li><a href=\"https://github.com/rbfinch\">Bob Finch</a>.</li>\n<li><a href=\"https://github.com/bobbywarner\">Bobby Warner</a>.</li>\n<li><a href=\"https://github.com/burtbeckwith\">Burt Beckwith</a>.</li>\n<li><a href=\"https://github.com/conalllaverty\">Conall Laverty</a>.</li>\n<li><a href=\"https://github.com/tkvw\">Dennie de Lange</a>.</li>\n<li><a href=\"https://github.com/dmahapatro\">Dhiraj Mahapatro</a>.</li>\n<li><a href=\"https://github.com/domurtag\">Donal Murtagh</a>.</li>\n<li><a href=\"https://github.com/liftyourgame\">Greg Pagendam-Turner</a>.</li>\n<li><a href=\"https://github.com/Schlogen\">James Kleeh</a>.</li>\n<li><a href=\"https://github.com/jladenfors\">Jonas Ladenfors</a>.</li>\n<li><a href=\"https://github.com/jagedn\">Jorge Aguilera</a>.</li>\n<li><a href=\"https://github.com/zeludo\">Ludovic Ronsin</a>.</li>\n<li><a href=\"https://github.com/stlhrt\">Lukasz Wozniak</a>.</li>\n<li><a href=\"https://github.com/marcos-carceles\">Marcos Carceles</a>.</li>\n<li><a href=\"https://github.com/michallula\">Micha\ufffd\ufffd\ufffd\ufffd\ufffd Lula</a>.</li>\n<li><a href=\"https://github.com/majkelo\">Michal Szulc</a>.</li>\n<li><a href=\"https://github.com/nllarson\">Nick Larson</a>.</li>\n<li><a href=\"https://github.com/peh\">Philipp Eschenbach</a>.</li>\n<li><a href=\"https://github.com/giboow\">Philippe Gibert</a>.</li>\n<li><a href=\"https://github.com/pphetra\">Polawat Phetra</a>.</li>\n<li><a href=\"https://github.com/rvargas\">Rafael Vargas</a>.</li>\n<li><a href=\"https://github.com/sbrady\">Sean Brady</a>.</li>\n<li><a href=\"https://github.com/Prototik\">Sergey Shatunov</a>.</li>\n<li><a href=\"https://github.com/sdelamo\">Sergio del Amo</a>.</li>\n<li><a href=\"https://github.com/sagrawal31\">Shashank Agrawal</a>.</li>\n<li><a href=\"https://github.com/srohlin\">Svante Rohlin</a>.</li>\n<li><a href=\"https://github.com/tcrespog\">Tom\ufffd\ufffd\ufffd\ufffds Crespo</a>.</li>\n<li><a href=\"https://github.com/tonyerskine\">Tony Erskine</a>.</li>\n<li><a href=\"https://github.com/vsaar\">Victor Saar</a>.</li>\n</ul>\n<h2>License</h2>\n<p>This software is licensed under the terms of the <a href=\"http://www.apache.org/licenses/LICENSE-2.0.html\">Apache License, Version 2.0</a></p>\n"
     },
     {
+        "deprecated": "The source repository for this entry states to use the entry with the same name from author valentingoebel. This entry should probably be removed from the registry to avoid confusion.",
         "bintrayPackage": {
             "name": "spring-security-saml",
             "repo": "plugins",
             "owner": "jeffwils",
             "desc": "Grails 3 Saml2 Support for Spring Security plugin.",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "saml"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -5958,21 +6120,23 @@
             "owner": "valentingoebel",
             "desc": "Grails spring-security-saml plugin",
             "labels": [
-                
+                "security",
+                "spring-security",
+                "saml"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails3-plugins/spring-security-saml/issues",
-            "latestVersion": "4.0.2",
-            "updated": "2020-01-15T08:51:05.629Z",
+            "latestVersion": "5.0.0-RC3",
+            "updated": "2022-07-13T16:45:25.000Z",
             "systemIds": [
-                "org.grails.plugins:spring-security-saml"
+                "io.github.grails-spring-security-saml:spring-security-saml"
             ],
-            "vcsUrl": "https://github.com/grails3-plugins/spring-security-saml"
+            "vcsUrl": "https://github.com/grails-spring-security-saml/grails-spring-security-saml"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/io/github/grails-spring-security-saml/spring-security-saml/maven-metadata.xml",
         "readme": null
     },
     {
@@ -5982,7 +6146,9 @@
             "owner": "grails",
             "desc": "Grails spring-security-shiro plugin",
             "labels": [
-                
+                "security",
+                "shiro",
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6006,7 +6172,8 @@
             "owner": "grails",
             "desc": "Grails Spring Security UI",
             "labels": [
-                
+                "security",
+                "spring-security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6030,7 +6197,7 @@
             "owner": "jeetmp3",
             "desc": "This plugin provides spring-session support in grails application.",
             "labels": [
-                
+                "http-session"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6054,15 +6221,13 @@
             "owner": "dmahapatro",
             "desc": "Spring WS Plugin for Grails 3",
             "labels": [
-                "grails",
-                "grails3",
-                "SOAP",
-                "Spring WS"
+                "soap",
+                "spring-ws"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/dmahapatro/grails-springws/tree/grails3/issues",
+            "issueTrackerUrl": "https://github.com/dmahapatro/grails-springws/issues",
             "latestVersion": "3.0.2",
             "updated": "2016-06-20T21:49:14.187Z",
             "systemIds": [
@@ -6081,7 +6246,7 @@
             "owner": "ajay-kumar",
             "desc": "Grails Swagger Plugin",
             "labels": [
-                
+                "swagger"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6090,8 +6255,8 @@
             "latestVersion": "1.0.1",
             "updated": "2019-04-06T11:55:00.162Z",
             "systemIds": [
-                "swagger:swagger",
-                "org.grails.plugins:swagger"
+                "org.grails.plugins:swagger",
+                "swagger:swagger"
             ],
             "vcsUrl": "https://github.com/ajay-kmr/swagger"
         },
@@ -6106,12 +6271,13 @@
             "owner": "donald-jackson",
             "desc": "Grails swagger4jaxrs plugin",
             "labels": [
-                
+                "swagger",
+                "jax-rs"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/swagger4jaxrs/issues",
+            "issueTrackerUrl": "https://github.com/donald-jackson/swagger4jaxrs/issues",
             "latestVersion": "3.0.2",
             "updated": "2016-05-18T10:06:43.567Z",
             "systemIds": [
@@ -6130,7 +6296,8 @@
             "owner": "captivatelabs",
             "desc": "The Grails Timezone Detection Plugin makes use of the jsTimezoneDetect Library in order to make the client/browser's timezone available on the server/JVM.",
             "labels": [
-                
+                "date",
+                "timezone"
             ],
             "licenses": [
                 "MIT"
@@ -6154,7 +6321,7 @@
             "owner": "novadge",
             "desc": "Use Twitter API to read and write twitter data",
             "labels": [
-                
+                "twitter"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6163,8 +6330,8 @@
             "latestVersion": "0.2.4",
             "updated": "2018-02-14T10:49:37.027Z",
             "systemIds": [
-                "org.grails.plugins:twitter",
-                "org.grails.plugins:twitter-service"
+                "org.grails.plugins:twitter-service",
+                "org.grails.plugins:twitter"
             ],
             "vcsUrl": "https://github.com/Novadge/twitter-service"
         },
@@ -6179,21 +6346,22 @@
             "owner": "bertramlabs",
             "desc": null,
             "labels": [
-                
+                "asset-pipeline",
+                "typescript"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/bertramdev/asset-pipeline/issues",
-            "latestVersion": "3.2.3",
-            "updated": "2020-06-30T17:01:56.322Z",
+            "latestVersion": "4.0.0",
+            "updated": "2022-11-03T15:33:49.000Z",
             "systemIds": [
                 "com.bertramlabs.plugins:typescript-asset-pipeline"
             ],
             "vcsUrl": "https://github.com/bertramdev/asset-pipeline.git"
         },
         "documentationUrl": "https://bertramdev.github.io/asset-pipeline/",
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/com/bertramlabs/plugins/typescript-asset-pipeline/maven-metadata.xml",
         "readme": null
     },
     {
@@ -6203,7 +6371,7 @@
             "owner": "mathifonseca",
             "desc": "Provides a friendlier way to update your application or plugin version.",
             "labels": [
-                
+                "util"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6227,7 +6395,7 @@
             "owner": "9ci",
             "desc": "Grails View tools - Grails plugin to help locate views in the spring mvc context",
             "labels": [
-                
+                "views"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6249,23 +6417,23 @@
             "name": "views-gradle",
             "repo": "plugins",
             "owner": "grails",
-            "desc": "Grails views-gradle plugin",
+            "desc": "Enables Gradle to compile views for production environment",
             "labels": [
-                
+                "views"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/grails/grails-views/issues",
-            "latestVersion": "1.2.10",
-            "updated": "2020-07-06T19:52:41.658Z",
+            "latestVersion": "2.3.2",
+            "updated": "2022-06-17T15:24:06.000Z",
             "systemIds": [
                 "org.grails.plugins:views-gradle"
             ],
             "vcsUrl": "https://github.com/grails/grails-views"
         },
-        "documentationUrl": "https://grails.github.io/grails-views/",
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://views.grails.org/latest/",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/views-gradle/maven-metadata.xml",
         "readme": "<h1>Grails Views</h1>\n<p>Additional View Technologies for Grails 3.0 and above.</p>\n<p>Initial implementation includes JSON views powered by Groovy's JsonBuilder, however this project provides the basis for implementation other view types.</p>\n<p>View <a href=\"https://grails.github.io/grails-views/latest/\">the latest documentation</a> for details.</p>\n<p><a href=\"https://github.com/grails/grails-views/actions/workflows/gradle.yml\"><img src=\"https://github.com/grails/grails-views/actions/workflows/gradle.yml/badge.svg?branch=master\" alt=\"Java CI\" /></a></p>\n"
     },
     {
@@ -6273,23 +6441,24 @@
             "name": "views-json-templates",
             "repo": "plugins",
             "owner": "grails",
-            "desc": "Grails views-json-templates plugin",
+            "desc": "If you are also using MongoDB you may want to add the views-json-templates plugin which includes support for GeoJSON",
             "labels": [
-                
+                "views",
+                "json"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/views-json-templates/issues",
-            "latestVersion": "1.2.10",
-            "updated": "2018-12-19T20:34:43.742Z",
+            "issueTrackerUrl": "https://github.com/grails/grails-views/issues",
+            "latestVersion": "2.3.2",
+            "updated": "2022-06-17T15:24:08.000Z",
             "systemIds": [
                 "org.grails.plugins:views-json-templates"
             ],
-            "vcsUrl": "https://github.com/grails3-plugins/views-json-templates"
+            "vcsUrl": "https://github.com/grails/grails-views"
         },
-        "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://views.grails.org/latest/",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/views-json-templates/maven-metadata.xml",
         "readme": null
     },
     {
@@ -6299,21 +6468,22 @@
             "owner": "grails",
             "desc": "Grails views-markup plugin",
             "labels": [
-                
+                "views",
+                "xml"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/views-markup/issues",
-            "latestVersion": "1.0.0.M2",
-            "updated": "2016-10-03T14:41:34.191Z",
+            "issueTrackerUrl": "https://github.com/grails/grails-views/issues",
+            "latestVersion": "2.3.2",
+            "updated": "2022-06-17T15:24:08.000Z",
             "systemIds": [
-                
+                "org.grails.plugins:views-markup"
             ],
-            "vcsUrl": "https://github.com/grails3-plugins/views-markup"
+            "vcsUrl": "https://github.com/grails/grails-views"
         },
-        "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "documentationUrl": "https://views.grails.org/latest/#_markup_views",
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/grails/plugins/views-markup/maven-metadata.xml",
         "readme": null
     },
     {
@@ -6323,7 +6493,7 @@
             "owner": "rlovtangen",
             "desc": "Grails wkhtmltopdf plugin",
             "labels": [
-                
+                "pdf"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6347,7 +6517,8 @@
             "owner": "vahid",
             "desc": "Grails wschat plugin",
             "labels": [
-                
+                "chat",
+                "websocket"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6356,8 +6527,8 @@
             "latestVersion": "3.0.16",
             "updated": "2016-03-31T13:31:55.147Z",
             "systemIds": [
-                "org.grails.plugins:grails-wschat-plugin",
-                "org.grails.plugins:wschat"
+                "org.grails.plugins:wschat",
+                "org.grails.plugins:grails-wschat-plugin"
             ],
             "vcsUrl": "https://github.com/vahidhedayati/grails-wschat-plugin"
         },
@@ -6372,7 +6543,7 @@
             "owner": "mrhaki",
             "desc": "Servlet filter that adds a X-FRAME-OPTIONS response header",
             "labels": [
-                
+                "security"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6396,7 +6567,9 @@
             "owner": "rpalcolea",
             "desc": "This plugin uses OWASP ESAPI library to sanitize request parameters. This reduces the risk of dangerous XSS request parameters possibly being rendered on the client.",
             "labels": [
-                
+                "security",
+                "xss",
+                "owasp"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6420,10 +6593,10 @@
             "owner": "vahidhedayati",
             "desc": "Grails payment plugin",
             "labels": [
-                "Paypal",
-                "Stripe",
-                "Square",
-                "Payment system"
+                "paypal",
+                "stripe",
+                "square",
+                "payment"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6437,7 +6610,7 @@
             "vcsUrl": "https://github.com/vahidhedayati/grails-payment"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null,
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/io/github/vahidhedayati/payment/maven-metadata.xml",
         "readme": "<div class=\"sect1\">\n<h2 id=\"_grails_payment_plugin\">Grails Payment Plugin</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>Payments made easy, supports paypal, stripe and square\n.</p>\n</div>\n<div class=\"paragraph\">\n<p>More information about using Payment methods:</p>\n</div>\n<div class=\"ulist\">\n<ul>\n<li>\n<p><a href=\"https://github.com/vahidhedayati/grails-payment\">Grails Payment plugin</a></p>\n</li>\n</ul>\n</div>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_installation\">Installation</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>These instructions are targeted towards Grails 4 installations. </p>\n</div>\n<div class=\"paragraph\">\n<p>Add a dependency to <code>build.gradle</code>:</p>\n</div>\n<div class=\"listingblock\">\n<div class=\"content\">\n<pre>...\ndependencies {\n    ...\n      compile 'io.github.vahidhedayati:payment:1.0.0'\n//You will only need this if you are looking to use square payment\n compile 'org.jetbrains.kotlin:kotlin-stdlib:1.3.70'\n ...\n}\n...</pre>\n</div>\n</div>\n<div class=\"paragraph\">\n<p>The default install needs configuration updated but will very easily connect / allow payments</p>\n</div>\n</div>\n<div class=\"sect1\">\n<h2 id=\"_configuration\">Configuration</h2>\n<div class=\"sectionbody\">\n<div class=\"paragraph\">\n<p>The plugin is configured through <code>grails-app/conf/application.groovy</code> refer to provided sampleApplication.groovy.</p>\n</div>\n</div>\n</div>\n"
     },
     {
@@ -6447,8 +6620,8 @@
             "owner": "ZenHarbinger",
             "desc": "Integration with Jasypt, allows easy encryption of information including Hibernate/GORM integration",
             "labels": [
-                "grails4",
-                "encryption"
+                "encryption",
+                "jasypt"
             ],
             "licenses": [
                 "Apache-2.0"
@@ -6459,10 +6632,10 @@
             "systemIds": [
                 "org.tros:jasypt-encryption"
             ],
-            "vcsUrl": "https://github.com/puneetbehl/myplugin"
+            "vcsUrl": "https://github.com/ZenHarbinger/grails-jasypt"
         },
         "documentationUrl": null,
-        "mavenMetadataUrl": null
+        "mavenMetadataUrl": "https://repo1.maven.org/maven2/org/tros/jasypt-encryption/maven-metadata.xml"
     },
     {
         "bintrayPackage": {
@@ -6471,8 +6644,6 @@
             "owner": "daraii",
             "desc": "This plugin is a port of the original JasperReports plugin later updated for Grails 3 to the newest JasperReports API, and based of Grails 5, that adds easy support for launching JasperReports reports from GSP pages.",
             "labels": [
-                "grails5",
-                "spring-boot",
                 "jasper",
                 "reports"
             ],
@@ -6497,14 +6668,15 @@
             "owner": "moceanapi",
             "desc": "This plugin allows helps you to incorporate SMS notification into your workflow.",
             "labels": [
-                "grails3"
+                "sms",
+                "moceanapi"
             ],
             "licenses": [
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/MoceanAPI/mocean-grails-sms/issues",
             "latestVersion": "1.0.1",
-            "updated": "2021-03-25T04:00:40.855Z",
+            "updated": "2022-08-10T10:40:37.000Z",
             "systemIds": [
                 "com.github.moceanapi:mocean-grails-sms"
             ],
@@ -6529,7 +6701,7 @@
             ],
             "issueTrackerUrl": "https://github.com/groovyzk/grailszk/issues",
             "latestVersion": "4.2.2",
-            "updated": "2021-12-26T18:51:13.000Z",
+            "updated": "2022-09-20T06:48:00.000Z",
             "systemIds": [
                 "io.github.zkgroovy:grailszk"
             ],
@@ -6545,7 +6717,8 @@
             "owner": "matrei",
             "desc": "Grails Adapter for Inertia.js",
             "labels": [
-                "inertia"
+                "inertia",
+                "spa"
             ],
             "licenses": [
                 "Apache-2.0"

--- a/grails-plugins.json
+++ b/grails-plugins.json
@@ -3537,8 +3537,8 @@
                 "Apache-2.0"
             ],
             "issueTrackerUrl": "https://github.com/gpc/jms/issues",
-            "latestVersion": "4.0.0",
-            "updated": "2022-11-15T17:30:00.000Z",
+            "latestVersion": "4.0.1",
+            "updated": "2021-12-26T11:24:51.000Z",
             "systemIds": [
                 "org.grails.plugins:jms"
             ],

--- a/grails-plugins.json
+++ b/grails-plugins.json
@@ -6127,7 +6127,7 @@
             "licenses": [
                 "Apache-2.0"
             ],
-            "issueTrackerUrl": "https://github.com/grails3-plugins/spring-security-saml/issues",
+            "issueTrackerUrl": "https://github.com/grails-spring-security-saml/grails-spring-security-saml/issues",
             "latestVersion": "5.0.0-RC3",
             "updated": "2022-07-13T16:45:25.000Z",
             "systemIds": [

--- a/grails-plugins.json
+++ b/grails-plugins.json
@@ -3625,7 +3625,7 @@
             ],
             "issueTrackerUrl": "https://github.com/gpc/jms/issues",
             "latestVersion": "4.0.1",
-            "updated": "2022-11-18T11:23:00.000Z",
+            "updated": "2022-11-18T11:24:51.000Z",
             "systemIds": [
                 "io.github.gpc:jms",
                 "org.grails.plugins:jms"


### PR DESCRIPTION
- Checked status
- Updated latestVersions and updated properties.
- Added deprecation and comment properties where I thought needed. The deprecation and comments does of course not do anything yet, but I am updating the portal application to display these.
- Added a displayName property to later be able to override the displayed name in portal application (without loosing the original name).
- Updated labels to remove redundant labels like 'grails', 'plugin' etc. and added general usable labels where I saw fit.
- Updated the systemIds so that the systemId of the last published version is first in the list. In the updated portal this will be used to make the Package-links work again and point to the latest version at https://repo.grails.org/ui/native/core/org/...
- Updated outdated links to documentation, issueTrackerUrl, vcsUrl etc.

I have tested this json file with the current version of the portal application (v2.2.0) and it works.