### PR TITLE
Grails X-Frame-Options plugin 2.x released

### DIFF
--- a/grails-plugins/org/grails/plugins/x-frame-options.yml
+++ b/grails-plugins/org/grails/plugins/x-frame-options.yml
@@ -2,8 +2,8 @@ name: x-frame-options
 desc: Servlet filter that adds a X-FRAME-OPTIONS response header
 coords: org.grails.plugins:x-frame-options
 owner: mrhaki
-vcs: https://github.com/mrhaki/grails-x-frame-options-plugin
-maven-repo: https://repo.grails.org/plugins
+vcs: https://github.com/grails-plugins/grails-x-frame-options-plugin
+maven-repo: https://repo1.maven.org/maven2
 labels:
   - security
 licenses:


### PR DESCRIPTION
The Grails X-Frame-Plugin has been released in a 2.0.0 version for Grails 7 and the code has moved to the Grails-Plugins organization on GitHub.