### PR TITLE
Added new plugins: RabbitMQ, Cache Guava, Taggable

### DIFF
--- a/grails-plugins/cloud/wondrify/grails-rabbitmq-amqp.yml
+++ b/grails-plugins/cloud/wondrify/grails-rabbitmq-amqp.yml
@@ -1,0 +1,13 @@
+name: Grails RabbitMQ AMQP Plugin
+desc: A RabbitMQ plugin for Grails that supports multiple connection factories, annotation-based consumer
+  configuration, and exchange/topic subscriptions.
+coords: cloud.wondrify:grails-rabbit-amqp-plugin
+owner: wondrify
+vcs: https://github.com/wondrify/grails-rabbit-amqp-plugin
+docs: https://wondrify.github.io/grails-rabbit-amqp-plugin/
+maven-repo: https://repo1.maven.org/maven2
+labels:
+  - messaging
+  - rabbitmq
+licenses:
+  - Apache-2.0

--- a/grails-plugins/io/github/gpc/grails-cache-guava.yml
+++ b/grails-plugins/io/github/gpc/grails-cache-guava.yml
@@ -1,0 +1,10 @@
+name: grails-cache-guava
+desc: The guava cache provides a simple in memory cache with maximal capacity and TTL.
+coords: io.github.gpc:grails-cache-guava
+owner: gpc
+vcs: https://github.com/gpc/grails-cache-guava
+maven-repo: https://repo1.maven.org/maven2
+labels:
+  - cache
+licenses:
+  - Apache-2.0

--- a/grails-plugins/io/github/gpc/taggable.yml
+++ b/grails-plugins/io/github/gpc/taggable.yml
@@ -1,0 +1,10 @@
+name: taggable
+desc: The Taggable plugin that adds a generic mechanism for tagging data
+coords: io.github.gpc:grails-taggable-plugin
+owner: Grails Plugin Collective
+vcs: https://github.com/gpc/taggable
+maven-repo: https://repo1.maven.org/maven2
+labels:
+  - tags
+licenses:
+  - Apache-2.0

--- a/grails-plugins/org/grails/plugins/hibernate-filter-plugin.yml
+++ b/grails-plugins/org/grails/plugins/hibernate-filter-plugin.yml
@@ -9,6 +9,7 @@ labels:
   - database
 licenses:
   - Apache-2.0
+deprecated: This repository was archived by the owner on Jan 7, 2025. It is now read-only.
 versions:
   - version: 0.5.5
     date: 2021-02-24T05:30:43Z


### PR DESCRIPTION
New version have been released within the last months, but they were not on the Grails Plugins portal:
 - Grails RabbitMQ AMQP Plugin
 - Grails Guava Cache
 - Taggable

 One plugin has been marked deprecated by its maintainer
 - Hibernate Filter Plugin