### PR TITLE
Added new Maven repo url for Grails Cache Ehcache

### DIFF
--- a/grails-plugins/org/grails/plugins/cache-ehcache.yml
+++ b/grails-plugins/org/grails/plugins/cache-ehcache.yml
@@ -4,7 +4,7 @@ coords: org.grails.plugins:cache-ehcache
 owner: grails-plugins
 vcs: https://github.com/grails-plugins/grails-cache-ehcache
 docs: https://grails-plugins.github.io/grails-cache-ehcache/latest/
-maven-repo: https://repo.grails.org/plugins
+maven-repo: https://repo1.maven.org/maven2
 labels:
   - cache
   - ehcache


### PR DESCRIPTION
A RC for Grails 7 has been released of the Grails Cache Ehcache plugin