### PR TITLE
ci: audit and update GitHub Actions to ASF-approved versions

### DIFF
--- a/.github/workflows/syncVersion.yml
+++ b/.github/workflows/syncVersion.yml
@@ -14,11 +14,11 @@ jobs:
       GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "🔄 Sync Latest Version"
         uses: ./.github/actions/sync-latest-version
       - name: "✨ Create Pull Request"
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           author: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
           commit-message: Update Plugins Metadata File

--- a/.github/workflows/updateIndex.yml
+++ b/.github/workflows/updateIndex.yml
@@ -15,11 +15,11 @@ jobs:
       GIT_USER_EMAIL: 'grails-build@users.noreply.github.com'
     steps:
       - name: "📥 Checkout repository"
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: "🔄 Update Plugin Index"
         uses: ./.github/actions/update-plugin-index
       - name: "✨ Create Pull Request"
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           author: ${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>
           commit-message: Update Plugin Index


### PR DESCRIPTION
## What

Audit of every GitHub Action used in this repository against the [ASF approved actions allow-list](https://github.com/apache/infrastructure-actions/blob/main/actions.yml), updating each to its current approved version and pinning every external action to a full commit SHA with a trailing comment naming the version it resolves to.

This mirrors the audit performed on grails-core in apache/grails-core#15690 and brings this repository back onto supported, allow-list-approved action versions.

## Changes

| Action | Before | After (pinned SHA # version) |
|--------|--------|------------------------------|
| `actions/checkout` | v4, v6 | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `peter-evans/create-pull-request` | v7, v8 | `5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1` |

First-party `apache/grails-github-actions/*` references and local `./.github/actions/*` composites are intentionally left unchanged.

## Verification

- Every external action is SHA-pinned with a `# version` comment; the only non-SHA refs remaining are the first-party `apache/*` `@asf` ones and local composite actions.
- All modified workflow YAML files parse cleanly.