### PR TITLE
Add audit logging 7.0.0 snapshot metadata

### DIFF
--- a/grails-plugins/org/grails/plugins/audit-logging.yml
+++ b/grails-plugins/org/grails/plugins/audit-logging.yml
@@ -11,6 +11,10 @@ licenses:
   - Apache-2.0
 comment: Now lives in https://github.com/grails-plugins/
 versions:
+  - version: 7.0.0-SNAPSHOT
+    date: 2026-08-08T00:41:07Z
+    grailsVersion: 8.0.0 > *
+    maven-repo: https://central.sonatype.com/repository/maven-snapshots
   - version: 6.0.0
     date: 2025-10-20T12:55:23Z
     grailsVersion: 7.0.0 > *


### PR DESCRIPTION
## Summary

- add `org.grails.plugins:audit-logging:7.0.0-SNAPSHOT` to the audit logging metadata
- mark the snapshot as compatible with Grails 8
- use the Maven Central snapshots repository for this version

## Source

- upstream `7.0.x` declares `projectVersion=7.0.0-SNAPSHOT` and targets Grails 8
- Sonatype metadata resolves build `7.0.0-20260808.004107-1`, published at `2026-08-08T00:41:07Z`

## Validation

- parsed the YAML and asserted coordinates, version, timestamp, Grails range, repository override, and uniqueness
- `git diff --check`
- YAML language-server diagnostics
